### PR TITLE
Refactor etcd TCP master-to-bootstrap preflight (csr_approver)

### DIFF
--- a/roles/csr_approver/tasks/etcd_tcp_master_to_bootstrap_preflight.yml
+++ b/roles/csr_approver/tasks/etcd_tcp_master_to_bootstrap_preflight.yml
@@ -78,13 +78,11 @@
       - -i
       - "{{ csr_approver_etcd_preflight_key_path }}"
       - "core@{{ _master_ip }}"
-      - timeout
-      - "10"
       - bash
-      - -c
-      - >-
-        timeout 3 bash -c "echo >/dev/tcp/{{ _boot_ip }}/2379"
-        && timeout 3 bash -c "echo >/dev/tcp/{{ _boot_ip }}/2380"
+      - -s
+    stdin: |
+      timeout 3 bash -c "echo >/dev/tcp/{{ _boot_ip }}/2379" &&
+      timeout 3 bash -c "echo >/dev/tcp/{{ _boot_ip }}/2380"
   register: csr_approver_etcd_preflight_cmd
   changed_when: false
   failed_when: false


### PR DESCRIPTION
## Description

Refactors `roles/csr_approver/tasks/etcd_tcp_master_to_bootstrap_preflight.yml` to streamline TCP connectivity checks from masters to the bootstrap etcd endpoint: clearer command layout, fewer redundant parameters, and a single `stdin` block for timeout-driven checks. Targets **#11**.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (role, playbook, or capability)
- [ ] Configuration change (inventory, group_vars, defaults)
- [ ] Documentation update
- [x] Refactor or cleanup
- [ ] Other (please describe):

## Affected Areas

<!-- Check all that apply -->

- [ ] Playbooks (`playbooks/`)
- [x] Roles (`roles/`)
- [ ] Inventory / group_vars
- [ ] Workflows (`.github/workflows/`)
- [ ] Documentation (README, AGENTS.md, role READMEs)

## Validation

<!-- Confirm you've run validation locally before opening this PR -->

- [x] `ansible-playbook playbooks/*.yml --syntax-check` passes
- [x] `ansible-lint` passes
- [ ] New playbooks added to `.github/workflows/ansible-validation.yml` (if applicable)

## Checklist

- [x] Changes are idempotent (safe to run multiple times)
- [x] No direct node OS modifications (use MachineConfigs for OCP nodes)
- [ ] New roles include `tasks/main.yml`, `defaults/main.yml`, and `README.md`
