### PR TITLE
hore: add pre-commit hook for ansible-lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+---
+repos:
+  - repo: https://github.com/ansible/ansible-lint
+    rev: v25.12.2
+    hooks:
+      - id: ansible-lint

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ source .venv/bin/activate   # On Windows: .venv\Scripts\activate
 pip install -r requirements-dev.txt
 ```
 
+**Pre-commit hooks** — Install hooks to run `ansible-lint` automatically on every commit:
+
+```bash
+pre-commit install
+```
+
 Install the required Ansible collections:
 
 ```bash

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,10 @@
 # CI validation dependencies (ansible-lint, ansible)
 # Used by .github/workflows/ansible-validation.yml
 ansible>=8.0.0
-ansible-lint>=8.0.0
+ansible-lint>=25.12.2
 
 # Required by amazon.aws collection for EC2, ELB, Route53, etc.
 boto3>=1.28.0
+
+# Required by ansible-lint for pre-commit integration
+pre-commit>=3.0.0


### PR DESCRIPTION
  Add .pre-commit-config.yaml with ansible-lint v25.12.2 hook to run
  linting automatically on every commit, mirroring CI validation.

  Update requirements-dev.txt to include pre-commit>=3.0.0 and pin
  ansible-lint>=25.12.2. Document setup in README.md.

## Description

<!-- Describe the changes in this PR. What problem does it solve? What does it add or modify? -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (role, playbook, or capability)
- [ ] Configuration change (inventory, group_vars, defaults)
- [ ] Documentation update
- [ ] Refactor or cleanup
- [ ] Other (please describe):

## Affected Areas

<!-- Check all that apply -->

- [ ] Playbooks (`playbooks/`)
- [ ] Roles (`roles/`)
- [ ] Inventory / group_vars
- [ ] Workflows (`.github/workflows/`)
- [ ] Documentation (README, AGENTS.md, role READMEs)

## Validation

<!-- Confirm you've run validation locally before opening this PR -->

- [ ] `ansible-playbook playbooks/*.yml --syntax-check` passes
- [ ] `ansible-lint` passes
- [ ] New playbooks added to `.github/workflows/ansible-validation.yml` (if applicable)

## Checklist

- [ ] Changes are idempotent (safe to run multiple times)
- [ ] No direct node OS modifications (use MachineConfigs for OCP nodes)
- [ ] New roles include `tasks/main.yml`, `defaults/main.yml`, and `README.md`
