### PR TITLE
fix: add oc-mirror v2 release-images path to mirror tag discovery

### DIFF
--- a/scripts/discover-mirror-release-tag.sh
+++ b/scripts/discover-mirror-release-tag.sh
@@ -231,8 +231,10 @@ discover_via_curl() {
   local auth out url last_err try
   local -a try_paths=("${REPO}")
   if [[ "${REPO}" == "openshift/release" ]]; then
-    # Prefer ocp-release repos; openshift/release/openshift/release often holds only per-component tags (4.21.z-arch-name).
+    # oc-mirror v2 uses openshift/release/openshift/release-images; v1 / oc adm uses openshift-release-dev/ocp-release.
+    # openshift/release/openshift/release holds only per-component tags (4.21.z-arch-name).
     try_paths+=(
+      "openshift/release/openshift/release-images"
       "openshift/release/openshift-release-dev/ocp-release"
       "openshift-release-dev/ocp-release"
       "openshift/release/openshift/release"


### PR DESCRIPTION
## Description

Adds the oc-mirror v2 `openshift/release/openshift/release-images` repository path to `discover-mirror-release-tag.sh` curl probe order so disconnected installs discover the correct release payload tags (instead of falling through to `ocp-release` layout paths).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (role, playbook, or capability)
- [ ] Configuration change (inventory, group_vars, defaults)
- [ ] Documentation update
- [ ] Refactor or cleanup
- [ ] Other (please describe):

## Affected Areas

<!-- Check all that apply -->

- [ ] Playbooks (`playbooks/`)
- [ ] Roles (`roles/`)
- [ ] Inventory / group_vars
- [ ] Workflows (`.github/workflows/`)
- [ ] Documentation (README, AGENTS.md, role READMEs)
- [x] Scripts (`scripts/`)

## Validation

<!-- Confirm you've run validation locally before opening this PR -->

- [x] `ansible-playbook playbooks/*.yml --syntax-check` passes
- [x] `ansible-lint` passes
- [x] New playbooks added to `.github/workflows/ansible-validation.yml` (if applicable)

## Checklist

- [x] Changes are idempotent (safe to run multiple times)
- [x] No direct node OS modifications (use MachineConfigs for OCP nodes)
- [x] New roles include `tasks/main.yml`, `defaults/main.yml`, and `README.md`
