### PR TITLE
Add disconnected RHOAI day-2 install and GPU worker defaults

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 ---
 # Dependabot configuration
+# PRs and manifest resolution use branch `dev` only (not the repo default branch).
 # Note: Ansible Galaxy (requirements.yml) is not supported by Dependabot.
 # For collection updates, consider Renovate (https://docs.renovatebot.com/modules/manager/ansible-galaxy/).
 
@@ -7,10 +8,12 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
 
   - package-ecosystem: "pip"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ venv/
 *.swp
 *.swo
 *~
+.idea/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,8 @@ This document helps AI agents understand and collaborate on the **gryphon-forge*
 
 ## Dependencies
 
-- **Tools:** `ansible` in `$PATH`; `openshift-install`, `oc`, and (when `forge_oc_mirror_install_enabled`) `oc-mirror` are placed under `install_dir/bin/` on the controller (Linux mirror download) and `bastion_install_dir/bin/` on the bastion, unless overridden via `openshift_install_binary_path` / `openshift_client_binary_path` / `openshift_oc_mirror_binary_path` (controller oc-mirror only)
-- **Ansible collections:** `amazon.aws`, `community.aws`, `kubernetes.core`, `community.general` (see `requirements.yml`)
+- **Tools:** `ansible` in `$PATH`; `openshift-install`, `oc`, and (when `forge_oc_mirror_install_enabled`) `oc-mirror` are placed under `install_dir/bin/` on the controller (Linux mirror download) and `bastion_install_dir/bin/` on the bastion, unless overridden via `openshift_install_binary_path` / `openshift_client_binary_path` / `openshift_oc_mirror_binary_path` (controller oc-mirror only; pinned path is copied into `install_dir/bin/oc-mirror`)
+- **Ansible collections:** `amazon.aws`, `community.aws`, `kubernetes.core`, `community.general`, `ansible.posix` (see `requirements.yml`)
 - **Secrets:** Pull secret at `~/.openshift/pull-secret` (or `PULL_SECRET_PATH`), SSH public key at `~/.ssh/id_rsa.pub`
 
 ## Playbook Tags

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,14 @@ This document helps AI agents understand and collaborate on the **gryphon-forge*
 | `inventory/hosts.yml` | Host inventory (local, bootstrap, masters, workers, gpu_workers) |
 | `playbooks/deploy_cluster.yml` | Main deployment playbook |
 | `playbooks/destroy_cluster.yml` | Teardown playbook |
+| `playbooks/install_rhoai.yml` | Day-2 RHOAI install (prep, storage, operators, DSC) |
 | `roles/ignition/` | Ignition generation (wraps `openshift-install`) |
 | `roles/aws_nodes/` | EC2, ELB, Route53 provisioning |
 | `roles/csr_approver/` | CSR approval during bootstrap |
 | `roles/validation/` | Post-install validation |
+| `roles/rhoai/` | OpenShift AI install after the cluster is up |
+| `scripts/mirror-rhoai.sh` | oc-mirror v2 helper for RHOAI catalogs/images |
+| `docs/RHOAI-disconnected-install.md` | Disconnected RHOAI + ai-accelerator guide |
 | `foundry_output.json` | Consumed from gryphon-foundry (VPC, subnets, SG, hosted zone) |
 
 ## Dependencies
@@ -61,6 +65,8 @@ ansible-galaxy collection install -r requirements.yml
 # 2. Syntax check all playbooks
 ansible-playbook playbooks/deploy_cluster.yml --syntax-check
 ansible-playbook playbooks/destroy_cluster.yml --syntax-check
+ansible-playbook playbooks/install_rhoai.yml --syntax-check
+ansible-playbook playbooks/preflight.yml --syntax-check
 
 # 3. Run ansible-lint
 ansible-lint
@@ -162,3 +168,4 @@ Set **`csr_approver_emit_console_ingress_hints_on_install_failure: true`** to pr
 - **Add a new role:** Create `roles/<name>/` with `tasks/main.yml`, `defaults/main.yml`, `README.md`.
 - **Change node counts:** Edit `inventory/group_vars/all.yml` (`master_count`, `worker_count`, `gpu_worker_count`).
 - **Add a playbook tag:** Add `tags:` to the relevant role in `deploy_cluster.yml`.
+- **Install RHOAI (day-2):** Mirror with `scripts/mirror-rhoai.sh`, then `ansible-playbook playbooks/install_rhoai.yml` (see `docs/RHOAI-disconnected-install.md`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ This document helps AI agents understand and collaborate on the **gryphon-forge*
 
 ## Dependencies
 
-- **Tools:** `ansible` in `$PATH`; `openshift-install` and `oc` are placed under `install_dir/bin/` on the controller (mirror download) and `bastion_install_dir/bin/` on the bastion, unless overridden via `openshift_install_binary_path` / `openshift_client_binary_path`
+- **Tools:** `ansible` in `$PATH`; `openshift-install`, `oc`, and (when `forge_oc_mirror_install_enabled`) `oc-mirror` are placed under `install_dir/bin/` on the controller (Linux mirror download) and `bastion_install_dir/bin/` on the bastion, unless overridden via `openshift_install_binary_path` / `openshift_client_binary_path` / `openshift_oc_mirror_binary_path` (controller oc-mirror only)
 - **Ansible collections:** `amazon.aws`, `community.aws`, `kubernetes.core`, `community.general` (see `requirements.yml`)
 - **Secrets:** Pull secret at `~/.openshift/pull-secret` (or `PULL_SECRET_PATH`), SSH public key at `~/.ssh/id_rsa.pub`
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ ansible-playbook playbooks/deploy_cluster.yml -e @foundry_output.json -e ec2_key
    ```
    See [Red Hat disconnected install docs](https://docs.openshift.com/container-platform/4.15/installing/disconnected_install/installing-mirroring-disconnected.html).
 
+   Alternative to hand-writing `imageset-config.yaml`: [mirror-gui](https://github.com/openshift/mirror-gui), a web UI for `oc-mirror v2` with a visual config builder, operator catalog browsing, and run monitoring. It runs in its own Podman container - see its repo for setup. Gryphon Forge does not install or manage it.
+
 3. **Add mirror registry to pull secret** — The Red Hat pull secret does not include your private mirror. Merge mirror `auths` into the same JSON you use for installs (see **Iron Gryphon** air-gapped setup in the team profile README: merge on the **bastion** with `oc registry login` or `podman login` to a temp `--authfile`, then `jq` **only** the `auths` maps—`{auths: ($a.auths * $b.auths)}`—not a top-level merge that drops Red Hat entries). Copy the merged file to your Ansible controller and set `PULL_SECRET_PATH`, or set **`mirror_registry_dockerconfig_extra_path`** in Forge to a mirror-only dockerconfig for tag discovery only.
 
 4. **Deploy with mirror** — Pass `mirror_registry_url` (from foundry output or `-e`):

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This project expects a `foundry_output.json` or access to the Terraform remote s
 ### 1. Prepare your environment
 The Forge requires the following tools:
 
-* **Controller (your machine):** The ignition role downloads `openshift-install` and `oc` into `install_dir/bin/` from the same `forge_ocp_mirror_base_url` / `forge_ocp_mirror_channel` as the bastion (Linux or macOS archives), so install state matches `gather bootstrap` / `wait-for` on the bastion. Override with `openshift_install_binary_path` / `openshift_client_binary_path` if the controller cannot reach the mirror. When using a bastion, CSR approval and validation still use Linux binaries under `bastion_install_dir/bin/` (see *Bastion OCP tools* below).
+* **Controller (your machine):** The ignition role downloads `openshift-install` and `oc` into `install_dir/bin/` from the same `forge_ocp_mirror_base_url` / `forge_ocp_mirror_channel` as the bastion (Linux or macOS archives), so install state matches `gather bootstrap` / `wait-for` on the bastion. On **Linux** controllers only, it also downloads `oc-mirror` into the same `install_dir/bin/` when `forge_oc_mirror_install_enabled` is true (same channel as `ocp_version` / `forge_ocp_mirror_channel`). Override with `openshift_install_binary_path` / `openshift_client_binary_path` if the controller cannot reach the mirror; set `openshift_oc_mirror_binary_path` to pin `oc-mirror` on the controller. When using a bastion, CSR approval and validation still use Linux binaries under `bastion_install_dir/bin/` (see *Bastion OCP tools* below).
 * `ansible` (with `amazon.aws`, `community.aws`, and `kubernetes.core` collections)
 
 **Virtual environment (recommended)** — Create and activate a virtual environment so Ansible uses the correct Python interpreter with all dependencies:
@@ -192,7 +192,7 @@ ansible-playbook playbooks/deploy_cluster.yml -e @foundry_output.json -e ec2_key
 - **Extra vars:** `-e bastion_ssh_private_key_path=../gryphon-foundry/bastion-key.pem` (path relative to CWD when run from `gryphon-forge/`)
 - **Default:** `~/.ssh/<ec2_key_name>.pem` (only when bastion key matches OCP key)
 
-**Bastion OCP tools** — When using a bastion, the playbook does *not* copy `openshift-install` or `oc` from your controller (avoiding Mac/Linux binary mismatch). Instead, the bastion downloads Linux-compatible binaries directly from `mirror.openshift.com`, matching the `ocp_version` in config (e.g. `latest-4.21`). The bastion must have internet access to the mirror for the first run. Override `forge_ocp_mirror_base_url` for air-gapped or internal mirrors.
+**Bastion OCP tools** — When using a bastion, the playbook does *not* copy `openshift-install` or `oc` from your controller (avoiding Mac/Linux binary mismatch). Instead, the bastion downloads Linux-compatible binaries directly from `mirror.openshift.com`, matching the `ocp_version` in config (e.g. `latest-4.21`). It also installs `oc-mirror` into `bastion_install_dir/bin/` from the same channel (rhel8 vs rhel9 tarball is chosen from the OS, or set `forge_ocp_oc_mirror_archive` explicitly). Put that directory on `PATH` when mirroring (e.g. `export PATH="{{ bastion_install_dir }}/bin:$PATH"`). Disable with `forge_oc_mirror_install_enabled: false` if you manage `oc-mirror` yourself. The bastion must have internet access to the mirror for the first run. Override `forge_ocp_mirror_base_url` for air-gapped or internal mirrors.
 
 **Disconnected / Air-Gapped Install** — The Vault has no internet. OCP nodes must pull images from a mirror registry reachable via VPC peering (e.g. in Nest).
 
@@ -204,8 +204,9 @@ ansible-playbook playbooks/deploy_cluster.yml -e @foundry_output.json -e ec2_key
 
 2. **Run oc-mirror from bastion** to populate the mirror registry:
    ```bash
-   # SSH to bastion, install oc-mirror, create imageset-config.yaml
-   # Then: oc mirror run --config imageset-config.yaml
+   # SSH to bastion; oc-mirror is under bastion_install_dir/bin when forge_oc_mirror_install_enabled (default).
+   # export PATH="/var/tmp/gryphon-forge-install/<cluster_name>/bin:$PATH"   # or your bastion_install_dir
+   # Create imageset-config.yaml, then e.g.: oc-mirror --v2 ... (see Red Hat docs for your OCP version)
    ```
    See [Red Hat disconnected install docs](https://docs.openshift.com/container-platform/4.15/installing/disconnected_install/installing-mirroring-disconnected.html).
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ This project expects a `foundry_output.json` or access to the Terraform remote s
 ### 1. Prepare your environment
 The Forge requires the following tools:
 
-* **Controller (your machine):** The ignition role downloads `openshift-install` and `oc` into `install_dir/bin/` from the same `forge_ocp_mirror_base_url` / `forge_ocp_mirror_channel` as the bastion (Linux or macOS archives), so install state matches `gather bootstrap` / `wait-for` on the bastion. On **Linux** controllers only, it also downloads `oc-mirror` into the same `install_dir/bin/` when `forge_oc_mirror_install_enabled` is true (same channel as `ocp_version` / `forge_ocp_mirror_channel`). Override with `openshift_install_binary_path` / `openshift_client_binary_path` if the controller cannot reach the mirror; set `openshift_oc_mirror_binary_path` to pin `oc-mirror` on the controller. When using a bastion, CSR approval and validation still use Linux binaries under `bastion_install_dir/bin/` (see *Bastion OCP tools* below).
-* `ansible` (with `amazon.aws`, `community.aws`, and `kubernetes.core` collections)
+* **Controller (your machine):** The ignition role downloads `openshift-install` and `oc` into `install_dir/bin/` from the same `forge_ocp_mirror_base_url` / `forge_ocp_mirror_channel` as the bastion (Linux or macOS archives), so install state matches `gather bootstrap` / `wait-for` on the bastion. On **Linux** controllers only, it also downloads `oc-mirror` into the same `install_dir/bin/` when `forge_oc_mirror_install_enabled` is true (default **false**; same channel as `ocp_version` / `forge_ocp_mirror_channel`). Override with `openshift_install_binary_path` / `openshift_client_binary_path` if the controller cannot reach the mirror; set `openshift_oc_mirror_binary_path` to an existing binary and Forge copies it into `install_dir/bin/oc-mirror` (skips the mirror download). When using a bastion, CSR approval and validation still use Linux binaries under `bastion_install_dir/bin/` (see *Bastion OCP tools* below).
+* `ansible` (with `amazon.aws`, `community.aws`, `kubernetes.core`, and `ansible.posix` collections)
 
 **Virtual environment (recommended)** — Create and activate a virtual environment so Ansible uses the correct Python interpreter with all dependencies:
 
@@ -192,7 +192,7 @@ ansible-playbook playbooks/deploy_cluster.yml -e @foundry_output.json -e ec2_key
 - **Extra vars:** `-e bastion_ssh_private_key_path=../gryphon-foundry/bastion-key.pem` (path relative to CWD when run from `gryphon-forge/`)
 - **Default:** `~/.ssh/<ec2_key_name>.pem` (only when bastion key matches OCP key)
 
-**Bastion OCP tools** — When using a bastion, the playbook does *not* copy `openshift-install` or `oc` from your controller (avoiding Mac/Linux binary mismatch). Instead, the bastion downloads Linux-compatible binaries directly from `mirror.openshift.com`, matching the `ocp_version` in config (e.g. `latest-4.21`). It also installs `oc-mirror` into `bastion_install_dir/bin/` from the same channel (rhel8 vs rhel9 tarball is chosen from the OS, or set `forge_ocp_oc_mirror_archive` explicitly). Put that directory on `PATH` when mirroring (e.g. `export PATH="{{ bastion_install_dir }}/bin:$PATH"`). Disable with `forge_oc_mirror_install_enabled: false` if you manage `oc-mirror` yourself. The bastion must have internet access to the mirror for the first run. Override `forge_ocp_mirror_base_url` for air-gapped or internal mirrors.
+**Bastion OCP tools** — When using a bastion, the playbook does *not* copy `openshift-install` or `oc` from your controller (avoiding Mac/Linux binary mismatch). Instead, the bastion downloads Linux-compatible binaries directly from `mirror.openshift.com`, matching the `ocp_version` in config (e.g. `latest-4.21`). When `forge_oc_mirror_install_enabled` is true, it also installs `oc-mirror` into `bastion_install_dir/bin/` from the same channel (`oc-mirror.rhel9.tar.gz` after a successful HEAD probe on EL9+/AL2023, otherwise the universal `oc-mirror.tar.gz`; override with `forge_ocp_oc_mirror_archive`). Put that directory on `PATH` when mirroring (e.g. `export PATH="{{ bastion_install_dir }}/bin:$PATH"`). Leave `forge_oc_mirror_install_enabled` false (default) if you manage `oc-mirror` yourself. The bastion must have internet access to the mirror for the first run. Override `forge_ocp_mirror_base_url` for air-gapped or internal mirrors.
 
 **Disconnected / Air-Gapped Install** — The Vault has no internet. OCP nodes must pull images from a mirror registry reachable via VPC peering (e.g. in Nest).
 
@@ -204,7 +204,7 @@ ansible-playbook playbooks/deploy_cluster.yml -e @foundry_output.json -e ec2_key
 
 2. **Run oc-mirror from bastion** to populate the mirror registry:
    ```bash
-   # SSH to bastion; oc-mirror is under bastion_install_dir/bin when forge_oc_mirror_install_enabled (default).
+   # SSH to bastion; enable forge_oc_mirror_install_enabled to place oc-mirror under bastion_install_dir/bin.
    # export PATH="/var/tmp/gryphon-forge-install/<cluster_name>/bin:$PATH"   # or your bastion_install_dir
    # Create imageset-config.yaml, then e.g.: oc-mirror --v2 ... (see Red Hat docs for your OCP version)
    ```

--- a/docs/RHOAI-disconnected-install.md
+++ b/docs/RHOAI-disconnected-install.md
@@ -1,0 +1,436 @@
+# RHOAI on a Gryphon Forge disconnected cluster
+
+Guide for installing **Red Hat OpenShift AI (RHOAI)** into an air-gapped OpenShift
+cluster provisioned by **gryphon-forge** (Vault) with a Nest mirror registry from
+**gryphon-foundry**.
+
+This document adapts two upstream projects to the Iron Gryphon topology:
+
+| Project | Role |
+|:--|:--|
+| [rh-aiservices-bu/disconnected-rhoai](https://github.com/rh-aiservices-bu/disconnected-rhoai) | How to **mirror** RHOAI (+ cert-manager, Service Mesh, NFD/GPU) and install operators/DSC in an air gap |
+| [redhat-ai-services/ai-accelerator](https://github.com/redhat-ai-services/ai-accelerator) | GitOps **day-2** stack (OpenShift GitOps / ArgoCD apps for RHOAI and related operators) |
+
+Upstream disconnected-rhoai is verified end-to-end for **OpenShift 4.20.30 + RHOAI 3.4.2**.
+Gryphon lab clusters may run a newer OCP minor than that example. Before pinning
+RHOAI versions, confirm support in
+[RHOAI supported configurations](https://access.redhat.com/articles/rhoai-supported-configs)
+and pick a RHOAI channel/version that lists your cluster’s OCP minor.
+
+---
+
+## Topology (Gryphon)
+
+```
+You / laptop
+    │
+    ▼
+Nest bastion (internet + SSH)          Vault VPC (no internet)
+  oc-mirror, pull secret                 OCP API / workers
+  mirror.fsi.internal (registry)  ◄──►   nodes pull only from mirror
+```
+
+| Host | Typical use in this guide |
+|:--|:--|
+| **Bastion** (Nest) | Run `oc-mirror`, push to `mirror.fsi.internal`, `oc` against the cluster |
+| **Controller** | Optional; keep kubeconfig from forge install |
+| **Cluster** | Consumes mirrored catalogs/images only |
+
+Forge defaults that matter:
+
+- `mirror_registry_url`: e.g. `mirror.fsi.internal`
+- Platform mirror layout (oc-mirror v2):  
+  `openshift/release/openshift/release-images` (payload) and  
+  `openshift/release/openshift/release` (art-dev / components)
+- Trust: `mirror_registry_additional_trust_bundle` from foundry → cluster `additionalTrustBundle`
+- Enable bastion `oc-mirror` with `forge_oc_mirror_install_enabled: true` (default is **false** on this branch)
+
+---
+
+## What you must mirror for RHOAI
+
+OpenShift platform content should already be on the mirror from the forge install.
+RHOAI needs a **second** mirror batch (large — hundreds of GB if you include all
+workbench/runtime images).
+
+| Content | Why |
+|:--|:--|
+| **rhods-operator** (RHOAI) | Operator + relatedImages |
+| **openshift-cert-manager-operator** | Hard prerequisite for RHOAI 3.x (`DSCInitialization` will not go Ready without it) |
+| **servicemeshoperator3** (OSSM / Sail) | Required for RHOAI 3.4 Data Science Gateway |
+| **nfd** + **gpu-operator-certified** | Optional unless you have GPU workers; still commonly mirrored |
+| **Workbench / notebook images** | **Not** fully discoverable via operator `relatedImages` — must be listed as `additionalImages` or workbenches fail with `ImagePullBackOff` |
+
+Upstream documents ~**517 GB** for a full RHOAI + workbench set (CUDA/ROCm/Gaudi
+variants). Plan Nest staging disk accordingly, or trim `additionalImages` to the
+CPU-only workbenches you need.
+
+Authoritative helper for workbench digests (version-matched):
+
+- <https://github.com/red-hat-data-services/rhoai-disconnected-install-helper>  
+  e.g. `rhoai-3.4.2.md` → “Additional images” section
+
+Worked YAML from disconnected-rhoai:
+
+- [imageset-config-rhoai.yaml](https://github.com/rh-aiservices-bu/disconnected-rhoai/blob/main/examples/rhoai-3.4.2-ocp-4.20.30/imageset-config-rhoai.yaml)
+- [idms / itms / CatalogSources](https://github.com/rh-aiservices-bu/disconnected-rhoai/tree/main/examples/rhoai-3.4.2-ocp-4.20.30)
+
+---
+
+## Prerequisites checklist
+
+1. **Cluster healthy** — forge `validation` passed; `oc get nodes` / `oc get co` look good.
+2. **Default StorageClass** — RHOAI needs a provisioner (EBS CSI on AWS UPI is typical).
+3. **Bastion can**:
+   - Reach the internet (for `registry.redhat.io` / `quay.io/modh`)
+   - Reach `https://mirror.fsi.internal` with the registry CA trusted
+   - Reach the OCP API (`api.<cluster>.fsi.internal:6443`) with kubeconfig
+4. **Pull secret** on bastion with Red Hat + mirror `auths` (same merge process as forge disconnected install).
+5. **Disk** — hundreds of GB free under your oc-mirror workspace / cache on Nest.
+6. **Versions** — set explicitly, for example:
+
+```bash
+export OCP_VERSION=4.22.8          # cluster version (already installed)
+export RHOAI_VERSION=3.4.2         # confirm supported on OCP 4.22 first
+export MIRROR=mirror.fsi.internal
+export CLUSTER_NAME=gryphon-ocp
+export BASE_DOMAIN=fsi.internal
+export KUBECONFIG=/var/tmp/gryphon-forge-install/${CLUSTER_NAME}/auth/kubeconfig
+export PATH="/var/tmp/gryphon-forge-install/${CLUSTER_NAME}/bin:$PATH"
+```
+
+---
+
+## Path A — Mirror + install (disconnected-rhoai style)
+
+Preferred for Gryphon: mirror from Nest bastion **directly into** the existing
+foundry registry (no separate Quay install), then apply cluster resources with `oc`.
+
+### A1. Install / refresh `oc-mirror` on the bastion
+
+From the forge repo (controller):
+
+```bash
+ansible-playbook playbooks/deploy_cluster.yml -i inventory/hosts.yml \
+  --tags csr_approval \
+  -e @../gryphon-foundry/foundry_output.json \
+  -e foundry_output_path=../gryphon-foundry/foundry_output.json \
+  -e bastion_ssh_private_key_path=../gryphon-foundry/bastion-key.pem \
+  -e forge_oc_mirror_install_enabled=true
+```
+
+Or copy a Linux `oc-mirror` matching your OCP channel onto the bastion manually.
+
+### A2. Create an RHOAI `ImageSetConfiguration`
+
+On the bastion, start from the upstream example and adjust:
+
+- Catalog digests / package versions for your chosen `RHOAI_VERSION`
+- `defaultChannel` on `rhods-operator` **must** match the channel you filter
+  (upstream note: filtering `stable-3.4` without setting `defaultChannel: stable-3.4`
+  makes oc-mirror refuse the catalog)
+- Destination path under your mirror (keep RHOAI content separate from the
+  platform `openshift/release/...` tree), e.g. `openshift/rhoai`
+
+Minimal operator set (illustrative — pin digests from a current example or
+`oc-mirror` dry-run):
+
+```yaml
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v2alpha1
+mirror:
+  operators:
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.22
+      packages:
+        - name: rhods-operator
+          defaultChannel: stable-3.4
+          channels:
+            - name: stable-3.4
+              minVersion: "3.4.2"
+              maxVersion: "3.4.2"
+        - name: openshift-cert-manager-operator
+          defaultChannel: stable-v1
+          channels:
+            - name: stable-v1
+        - name: servicemeshoperator3
+          defaultChannel: stable
+          channels:
+            - name: stable
+        - name: nfd
+          defaultChannel: stable
+          channels:
+            - name: stable
+    - catalog: registry.redhat.io/redhat/certified-operator-index:v4.22
+      packages:
+        - name: gpu-operator-certified
+          defaultChannel: stable
+          channels:
+            - name: stable
+  additionalImages: []   # fill from rhoai-disconnected-install-helper (see A3)
+```
+
+Use catalog **digests** when possible (tag → digest). Upstream warns that some
+tag-only references cause oc-mirror to fall back to the network incorrectly.
+
+### A3. Add workbench `additionalImages`
+
+Fetch the version-matched list (example for 3.4.2):
+
+```bash
+curl -sfL \
+  https://raw.githubusercontent.com/red-hat-data-services/rhoai-disconnected-install-helper/main/rhoai-${RHOAI_VERSION}.md \
+  | awk '/^# Additional images/{a=1; next} /^# (Unsupported|ImageSetConfiguration)/{a=0} a' \
+  | grep -oE '(quay\.io|registry\.redhat\.io)[^ ]+@sha256:[a-f0-9]+' \
+  | sort -u
+```
+
+Convert each line to ImageSet `additionalImages` entries (`- name: <ref>`).
+Optionally keep only CPU Jupyter/minimal images to shrink the mirror.
+
+### A4. Mirror to the Nest registry (oc-mirror v2)
+
+On the bastion (internet + registry CA trusted):
+
+```bash
+mkdir -p ~/oc-mirror-workspace-rhoai ~/imagesets
+# write imageset-config-rhoai.yaml as above
+
+oc-mirror --v2 \
+  -c ~/imagesets/imageset-config-rhoai.yaml \
+  --workspace file://$(pwd)/oc-mirror-workspace-rhoai \
+  "docker://${MIRROR}/openshift/rhoai" \
+  --authfile ~/.openshift/pull-secret
+```
+
+Expect a long runtime. When finished, oc-mirror emits cluster resources under
+something like:
+
+`~/oc-mirror-workspace-rhoai/working-dir/cluster-resources/`
+
+Typical artifacts:
+
+| File | Purpose |
+|:--|:--|
+| `idms-oc-mirror.yaml` | `ImageDigestMirrorSet` |
+| `itms-oc-mirror.yaml` | `ImageTagMirrorSet` (if tags were mirrored) |
+| `cs-*.yaml` | Mirrored `CatalogSource`s |
+
+### A5. Apply mirror config to the cluster
+
+```bash
+oc apply -f ~/oc-mirror-workspace-rhoai/working-dir/cluster-resources/
+
+# Confirm catalogs and packages
+oc get catalogsource -n openshift-marketplace
+oc get packagemanifest -n openshift-marketplace | grep -E 'rhods|cert-manager|servicemesh|nfd|gpu-operator'
+```
+
+If forge already applied platform IDMS for `openshift/release/...`, keep both:
+RHOAI IDMS entries should redirect `registry.redhat.io` / `quay.io/modh` (etc.)
+to `${MIRROR}/...` without breaking the existing release mirrors.
+
+### A6. Install operators (order matters)
+
+Suggested order (mirrors [disconnected-rhoai phase 40](https://github.com/rh-aiservices-bu/disconnected-rhoai/blob/main/scripts/rhoai/40-install-operators.sh)):
+
+1. **cert-manager** (`openshift-cert-manager-operator`)
+2. **Service Mesh 3** (`servicemeshoperator3`) if using RHOAI 3.4 gateway features
+3. **NFD**, then **NVIDIA GPU Operator** (only if GPU workers exist / desired)
+4. **RHOAI** (`rhods-operator`) in `redhat-ods-operator` (AllNamespaces OperatorGroup)
+
+Resolve CatalogSource names from PackageManifests rather than hard-coding:
+
+```bash
+oc get packagemanifest rhods-operator -n openshift-marketplace \
+  -o jsonpath='{.status.catalogSource}{"\n"}'
+```
+
+Wait until CSVs are `Succeeded` before continuing:
+
+```bash
+oc get csv -A | grep -E 'cert-manager|servicemesh|rhods|nfd|gpu-operator'
+```
+
+### A7. Configure RHOAI (`DSCInitialization` then `DataScienceCluster`)
+
+Apply **DSCI first** and wait until Ready; then apply **DSC**. Applying both at
+once can race (upstream phase 50 note).
+
+Use manifests from:
+
+- [disconnected-rhoai examples](https://github.com/rh-aiservices-bu/disconnected-rhoai/tree/main/examples/rhoai-3.4.2-ocp-4.20.30)
+  (`dscinitialization.yaml`, `datasciencecluster.yaml`)
+
+Adapt:
+
+- Management / applications namespaces as required by your RHOAI minor
+- Trusted CA / mirror CA if the DSCI template expects a PEM (Nest registry CA)
+- Component set to match the **apiVersion** of the installed CRD (3.x removed /
+  renamed several 2.x fields)
+
+```bash
+oc apply -f dscinitialization.yaml
+oc wait dscinitialization default-dsci --for=condition=Ready --timeout=20m
+
+oc apply -f datasciencecluster.yaml
+oc get datasciencecluster -A
+oc get csv -n redhat-ods-operator
+```
+
+### A8. Verify
+
+```bash
+oc get dscinitialization,datasciencecluster -A
+oc get pods -n redhat-ods-applications
+oc get route -n redhat-ods-applications   # dashboard
+# Create a test Data Science Project + CPU workbench — confirms workbench images pulled
+```
+
+Dashboard URL is typically under `*.apps.${CLUSTER_NAME}.${BASE_DOMAIN}`.
+
+---
+
+## Path B — ai-accelerator GitOps (after images exist)
+
+Once catalogs and images are mirrored (Path A), you can manage day-2 config with
+[ai-accelerator](https://github.com/redhat-ai-services/ai-accelerator) instead of
+(or in addition to) one-shot YAML.
+
+### B1. Fork and pick an overlay
+
+Clone / fork the repo. Bootstrap overlays include (non-exhaustive):
+
+- `bootstrap/overlays/rhoai-stable-3.4-aws-gpu`
+- `bootstrap/overlays/rhoai-stable-3.3-aws-gpu`
+- `bootstrap/overlays/rhoai-eus-2.25`
+
+See [installation.md](https://github.com/redhat-ai-services/ai-accelerator/blob/main/documentation/installation.md).
+
+### B2. Disconnected constraints
+
+- ArgoCD / OpenShift GitOps must also be **mirrored** (operator + operand images)
+  before `./bootstrap.sh`, or GitOps itself will `ImagePullBackOff`.
+- Point GitOps to **your fork** (air-gapped clusters often sync from an internal
+  Git server, not github.com).
+- Operator Subscriptions created by Argo must use the **mirrored CatalogSources**
+  from Path A (not `redhat-operators` from the public marketplace).
+- MinIO and other sample apps pull public images — mirror those or disable the
+  overlays you do not need.
+
+### B3. Bootstrap (connected-style flow; adapt for air gap)
+
+```bash
+oc login ...   # cluster-admin
+./bootstrap.sh
+# select overlay matching your RHOAI channel, e.g. rhoai-stable-3.4-aws-gpu
+```
+
+Then:
+
+```bash
+oc adm groups add-users gitops-admins $(oc whoami)
+oc get routes openshift-gitops-server -n openshift-gitops
+```
+
+Expect 10–15+ minutes for Applications to settle; Subscriptions may show
+`Progressing` long after the Operator appears Installed (OLM reconciliation).
+
+---
+
+## GPU notes (Forge)
+
+- Forge can provision `gpu_worker_count` / `gpu_worker_instance_type` in
+  `inventory/group_vars/all.yml` (default: **3× `g6.4xlarge`** for RHOAI).
+- Mirror NFD + NVIDIA GPU Operator **before** attaching GPU nodes that expect
+  drivers (`INCLUDE_GPU=true` with `scripts/mirror-rhoai.sh`, then
+  `rhoai_install_gpu_stack=true` on `playbooks/install_rhoai.yml`).
+- Without GPU nodes, skip GPU Operator Subscriptions and prefer CPU workbench
+  images only.
+
+---
+
+## Storage sizing (planning)
+
+| Item | Ballpark |
+|:--|:--|
+| Platform OCP mirror (already done) | ~20 GB |
+| RHOAI operators only | much smaller than full set |
+| RHOAI + full workbench/runtimes | **~500+ GB** (upstream measurement) |
+| Nest free space recommendation | ≥ 1–1.5 TB if mirroring the full set |
+
+Reclaim oc-mirror cache/workspace between platform and RHOAI batches when disk is
+tight (upstream `16-cleanup-staging` pattern).
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|:--|:--|
+| `ImagePullBackOff` on workbench | Missing `additionalImages` / workbench digests not mirrored |
+| DSCI never Ready | cert-manager not installed or not healthy |
+| DSC components stuck | Operator CSV not Succeeded; wrong CRD/apiVersion fields for RHOAI minor |
+| Catalog empty / package missing | CatalogSource not applied or wrong index digest for OCP minor |
+| TLS errors to mirror | Nest registry CA not in cluster trust / node trust |
+| Argo apps ImagePullBackOff | GitOps operands not mirrored; still pointing at quay.io |
+| `invalid default channel` from oc-mirror | Set `defaultChannel` on filtered `rhods-operator` package |
+
+Useful checks:
+
+```bash
+oc get idms,itms
+oc get catalogsource,packagemanifest -n openshift-marketplace
+oc describe dscinitialization default-dsci
+oc describe datasciencecluster
+oc get events -n redhat-ods-applications --sort-by=.lastTimestamp | tail -40
+```
+
+---
+
+## Suggested runbook (Ansible)
+
+Forge automation for steps below lives in:
+
+| Artifact | Purpose |
+|:--|:--|
+| `scripts/mirror-rhoai.sh` | Bastion-side oc-mirror v2 batch (operators + optional workbenches) |
+| `playbooks/install_rhoai.yml` + `roles/rhoai/` | Prep, StorageClass/EBS CSI, operators, DSCI/DSC, verify |
+
+1. Confirm RHOAI version supported on your cluster’s OCP minor (supported-configs article).
+2. On bastion: enable `oc-mirror`, trust the Nest mirror, merged pull secret.
+3. Mirror RHOAI content:
+
+```bash
+export MIRROR_REGISTRY_URL=mirror.fsi.internal
+export OCP_MINOR=4.22          # match your cluster minor
+export RHOAI_CHANNEL=stable-3.4
+export RHOAI_VERSION=3.4.2
+./scripts/mirror-rhoai.sh
+```
+
+4. Install RHOAI (storage prep + operators + DSCI/DSC):
+
+```bash
+ansible-playbook playbooks/install_rhoai.yml -i inventory/hosts.yml \
+  -e @../gryphon-foundry/foundry_output.json \
+  -e foundry_output_path=../gryphon-foundry/foundry_output.json \
+  -e bastion_ssh_private_key_path=../gryphon-foundry/bastion-key.pem \
+  -e rhoai_apply_mirror_resources=true \
+  -e rhoai_mirror_resources_dir=$HOME/oc-mirror-workspace-rhoai/working-dir/cluster-resources \
+  -e rhoai_channel=stable-3.4
+```
+
+5. Optional: deploy **ai-accelerator** GitOps overlay once GitOps images are mirrored
+   (see Path B). Manual Path A steps remain documented above for debugging.
+
+---
+
+## References
+
+- [disconnected-rhoai](https://github.com/rh-aiservices-bu/disconnected-rhoai) — mirror phases, imagesets, DSC examples
+- [disconnected-rhoai CHEATSHEET](https://github.com/rh-aiservices-bu/disconnected-rhoai/blob/main/CHEATSHEET.md) — working on an existing disconnected cluster
+- [ai-accelerator](https://github.com/redhat-ai-services/ai-accelerator) — GitOps bootstrap
+- [ai-accelerator installation](https://github.com/redhat-ai-services/ai-accelerator/blob/main/documentation/installation.md)
+- [rhoai-disconnected-install-helper](https://github.com/red-hat-data-services/rhoai-disconnected-install-helper) — additional image lists per RHOAI version
+- [RHOAI supported configurations](https://access.redhat.com/articles/rhoai-supported-configs)
+- Gryphon Forge disconnected notes — root `README.md` (oc-mirror, IDMS, pull secret merge)

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -34,7 +34,7 @@ foundry_ingress_certificate_arn: ""  # ACM cert ARN from foundry; when set, uses
 # --- Cluster Configuration ---
 cluster_name: "iron-vault-01"
 base_domain: "fsi.internal"
-ocp_version: "4.21"
+ocp_version: "4.22"
 # True → oauth-openshift.apps on API NLB (#23/#24). False → same as *.apps / ingress (#30). Default follows ocp_version vs 4.21.
 forge_oauth_apps_via_api_nlb: "{{ ocp_version is version('4.21', '<') }}"
 
@@ -104,9 +104,13 @@ mirror_registry_url: ""  # e.g. mirror.fsi.internal or mirror.fsi.internal:443 (
 # Aligns install-config + cluster mirror CRs with oc adm release mirror / IDMS instructions (OCP 4.12+).
 mirror_registry_use_image_digest_sources: true
 # Must match the repository path on the mirror — the segment after docker://<host>/ in your mirror command; tag discovery calls GET /v2/<path>/tags/list.
-# Example oc-mirror v2 (mirror-to-registry): ... "docker://${MIRROR_REGISTRY_URL}/openshift/release" --v2  ->  openshift/release below
-# oc-mirror: ocp-release tags are often under .../openshift-release-dev/ocp-release; .../openshift/release may be component-only tags.
-mirror_registry_release_path: "openshift/release"
+# Example oc-mirror v2 (mirror-to-registry): ... "docker://${MIRROR_REGISTRY_URL}/openshift/release" --v2
+#   Payload tags (4.x.z-x86_64) → openshift/release/openshift/release-images (set below)
+#   Component images → openshift/release/openshift/release (mirror_registry_art_dev_path)
+# Discovery also probes nested paths when this is left at openshift/release.
+mirror_registry_release_path: "openshift/release/openshift/release-images"
+# oc-mirror v2 art-dev / component mirror path (install-config + IDMS). Empty → same as mirror_registry_release_path.
+mirror_registry_art_dev_path: "openshift/release/openshift/release"
 # discover-mirror-release-tag.sh: GET ${scheme}://<mirror>/v2/... (set http only if the registry does not serve HTTPS).
 mirror_registry_discovery_scheme: "https"
 # PEM for the registry CA (or self-signed server cert). Required when the mirror is not in the system trust store.

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -41,12 +41,13 @@ forge_oauth_apps_via_api_nlb: "{{ ocp_version is version('4.21', '<') }}"
 # --- Node Counts ---
 master_count: 3
 worker_count: 3
-gpu_worker_count: 1
+gpu_worker_count: 3
 
 # --- Instance Sizing ---
 master_instance_type: "m6i.xlarge"
 worker_instance_type: "m6i.2xlarge"
-gpu_worker_instance_type: "g5.xlarge"
+# g6.4xlarge = 1× NVIDIA L4 (24 GiB); used for RHOAI GPU workloads
+gpu_worker_instance_type: "g6.4xlarge"
 
 # --- Paths ---
 install_dir: "{{ playbook_dir | default('.') }}/../installer/{{ cluster_name }}"

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -156,7 +156,13 @@ forge_ocp_mirror_validate_certs: true
 # Same URLs used by the ignition role on the controller so install state matches bastion binaries.
 forge_ocp_installer_url_linux: "{{ forge_ocp_mirror_base_url }}/{{ forge_ocp_mirror_channel }}/openshift-install-linux.tar.gz"
 forge_ocp_client_url_linux: "{{ forge_ocp_mirror_base_url }}/{{ forge_ocp_mirror_channel }}/openshift-client-linux.tar.gz"
+# oc-mirror tarball in the same channel directory (e.g. oc-mirror.rhel9.tar.gz). Empty = auto rhel8 vs rhel9 from ansible_facts.
+forge_ocp_oc_mirror_archive: ""
+# When true (default): install oc-mirror next to openshift-install/oc from forge_ocp_mirror_* (Linux bastion + Linux controller).
+forge_oc_mirror_install_enabled: true
 # Controller: leave empty to auto-download openshift-install + oc into install_dir/bin (Linux/macOS).
 # Set both to absolute paths for air-gapped controllers or unsupported OS.
 openshift_install_binary_path: ""
 openshift_client_binary_path: ""
+# Controller only: absolute path to oc-mirror when not using auto-download (e.g. air-gapped). Bastion always uses channel download when enabled.
+openshift_oc_mirror_binary_path: ""

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -161,13 +161,16 @@ forge_ocp_mirror_validate_certs: true
 # Same URLs used by the ignition role on the controller so install state matches bastion binaries.
 forge_ocp_installer_url_linux: "{{ forge_ocp_mirror_base_url }}/{{ forge_ocp_mirror_channel }}/openshift-install-linux.tar.gz"
 forge_ocp_client_url_linux: "{{ forge_ocp_mirror_base_url }}/{{ forge_ocp_mirror_channel }}/openshift-client-linux.tar.gz"
-# oc-mirror tarball in the same channel directory (e.g. oc-mirror.rhel9.tar.gz). Empty = auto rhel8 vs rhel9 from ansible_facts.
+# oc-mirror tarball in the same channel directory. Empty = auto (prefer oc-mirror.rhel9.tar.gz after HEAD
+# probe on EL9+/AL2023; otherwise oc-mirror.tar.gz). Do not set oc-mirror.rhel8.tar.gz — it 404s on the public mirror.
 forge_ocp_oc_mirror_archive: ""
-# When true (default): install oc-mirror next to openshift-install/oc from forge_ocp_mirror_* (Linux bastion + Linux controller).
-forge_oc_mirror_install_enabled: true
+# When true: install oc-mirror next to openshift-install/oc from forge_ocp_mirror_* (Linux bastion + Linux controller).
+# Default false so CSR/bastion sync does not hard-fail when oc-mirror is unused; set true for disconnected mirroring.
+forge_oc_mirror_install_enabled: false
 # Controller: leave empty to auto-download openshift-install + oc into install_dir/bin (Linux/macOS).
 # Set both to absolute paths for air-gapped controllers or unsupported OS.
 openshift_install_binary_path: ""
 openshift_client_binary_path: ""
-# Controller only: absolute path to oc-mirror when not using auto-download (e.g. air-gapped). Bastion always uses channel download when enabled.
+# Controller only: absolute path to an existing oc-mirror binary. When set, Forge copies it into install_dir/bin/oc-mirror
+# (skips mirror download). Bastion still uses channel download when forge_oc_mirror_install_enabled is true.
 openshift_oc_mirror_binary_path: ""

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -66,8 +66,9 @@ ssh_public_key_path: "{{ lookup('env', 'SSH_PUBLIC_KEY_PATH') | default('~/.ssh/
 ocp_ssh_private_key_path: "{{ lookup('env', 'OCP_SSH_PRIVATE_KEY_PATH') | default(ssh_public_key_path | regex_replace('\\.pub$', ''), true) }}"
 
 # --- Bastion (for API access; populated from foundry, no hardcoding) ---
-# When foundry provides bastion_public_ip/bastion_public_dns, install_dir is synced
-# to bastion and CSR approval/validation run there (reach cluster API in private VPC).
+# When foundry provides bastion_public_ip/bastion_public_dns, install artifacts (auth, ignition,
+# manifests, etc.) are rsync'd to bastion; openshift-install and oc are downloaded on the bastion
+# from the mirror (Linux). CSR approval/validation run there (reach cluster API in private VPC).
 # Use /var/tmp (not /tmp) - bastion /tmp is often tmpfs (~459MB) with insufficient space
 # for install dir + OCP tools (~800MB). Override via -e bastion_install_dir=... if needed.
 bastion_install_dir: "/var/tmp/gryphon-forge-install/{{ cluster_name }}"

--- a/playbooks/deploy_cluster.yml
+++ b/playbooks/deploy_cluster.yml
@@ -640,6 +640,18 @@
         - csr_approval
         - validation
 
+    - name: Ensure oc-mirror on bastion matches OCP mirror channel
+      ansible.builtin.include_role:
+        name: ignition
+        tasks_from: ensure_oc_mirror_install.yml
+      vars:
+        ignition_oc_mirror_target_bin_dir: "{{ bastion_install_dir }}/bin"
+        ignition_oc_mirror_download_tmp: "/var/tmp/gryphon-forge-oc-mirror-dl-{{ cluster_name }}"
+      when: forge_oc_mirror_install_enabled | default(true) | bool
+      tags:
+        - csr_approval
+        - validation
+
     - name: Remove temp directory
       ansible.builtin.file:
         path: "{{ forge_bastion_tmp }}"

--- a/playbooks/deploy_cluster.yml
+++ b/playbooks/deploy_cluster.yml
@@ -458,11 +458,16 @@
     # Use /var/tmp to avoid /tmp space limits (openshift-install tarball ~395MB)
     forge_bastion_tmp: "/var/tmp/gryphon-forge-ocp-tools"
   tasks:
+    # ansible.cfg often sets become=true globally; directories created as root break synchronize because
+    # rsync over SSH runs as ansible_user (ec2-user), not root.
     - name: Ensure bastion install directory exists
       ansible.builtin.file:
         path: "{{ bastion_install_dir }}"
         state: directory
         mode: "0755"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+      become: false
       tags:
         - csr_approval
         - validation
@@ -472,6 +477,22 @@
         path: "{{ bastion_install_dir }}/bin"
         state: directory
         mode: "0755"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+      become: false
+      tags:
+        - csr_approval
+        - validation
+
+    # Repair root:root trees from older runs (copy/become) so ec2-user can rsync into this path.
+    - name: Align ownership on bastion install dir for synchronize SSH user
+      ansible.builtin.file:
+        path: "{{ bastion_install_dir }}"
+        state: directory
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        recurse: true
+      become: true
       tags:
         - csr_approval
         - validation
@@ -496,6 +517,7 @@
         dest: "{{ bastion_install_dir }}/"
         archive: true
         delete: false
+        times: false
         # delegate_to: localhost uses a local connection; rsync's ssh must get the bastion key explicitly.
         # Relative paths must be absolute: rsync's subprocess cwd is not the project directory (ssh -i would fail).
         private_key: >-

--- a/playbooks/deploy_cluster.yml
+++ b/playbooks/deploy_cluster.yml
@@ -476,6 +476,17 @@
         - csr_approval
         - validation
 
+    # ansible.posix.synchronize runs rsync on the controller and invokes rsync --server on the bastion over SSH.
+    # Minimal AMIs often omit rsync; install before sync.
+    - name: Ensure rsync is installed on bastion (remote rsync helper for synchronize)
+      ansible.builtin.package:
+        name: rsync
+        state: present
+      become: true
+      tags:
+        - csr_approval
+        - validation
+
     - name: Rsync install artifacts to bastion (exclude controller bin and download cache)
       vars:
         # Raw path from inventory / -e (may be relative to where ansible-playbook was started).

--- a/playbooks/deploy_cluster.yml
+++ b/playbooks/deploy_cluster.yml
@@ -442,7 +442,8 @@
         - dns_gate
 
 # Runs only when bastion was added via add_host (foundry provides bastion_public_ip/bastion_public_dns)
-# Bastion downloads openshift-install and oc from Red Hat mirror (Linux binaries, version-compatible)
+# Install *artifacts* rsync from controller (exclude bin/ + .forge-download-cache/). Bastion downloads
+# Linux openshift-install + oc from the mirror below — never push controller binaries to the bastion.
 # TMPDIR avoids /tmp (459MB tmpfs) - Ansible modules use /var/tmp for temp files
 - name: Sync install directory to bastion for API access
   hosts: bastion
@@ -453,6 +454,7 @@
     # Foundry overrides apply to localhost in the first play; bastion must use the same identity for paths and DNS.
     cluster_name: "{{ hostvars['localhost']['cluster_name'] }}"
     base_domain: "{{ hostvars['localhost']['base_domain'] }}"
+    forge_controller_install_dir: "{{ hostvars['localhost']['install_dir'] }}"
     # Use /var/tmp to avoid /tmp space limits (openshift-install tarball ~395MB)
     forge_bastion_tmp: "/var/tmp/gryphon-forge-ocp-tools"
   tasks:
@@ -474,35 +476,16 @@
         - csr_approval
         - validation
 
-    - name: Copy install directory from controller to bastion
-      ansible.builtin.copy:
-        src: "{{ install_dir }}/"
+    - name: Rsync install artifacts to bastion (exclude controller bin and download cache)
+      ansible.posix.synchronize:
+        src: "{{ forge_controller_install_dir | expanduser }}/"
         dest: "{{ bastion_install_dir }}/"
-        mode: "0644"
-      tags:
-        - csr_approval
-        - validation
-
-    # Copy brings controller bin/oc + openshift-install (often macOS from a Darwin laptop). Remove anything
-    # that is not Linux ELF so the next task re-fetches Linux bits from the mirror.
-    - name: Remove non-ELF openshift-install and oc after controller copy (Darwin controller → Linux bastion)
-      ansible.builtin.shell: |
-        set -euo pipefail
-        removed=0
-        elf_hdr() {
-          [ -f "$1" ] || return 1
-          h=$(head -c 4 "$1" | od -An -t x1 | tr -d '[:space:]')
-          case "$h" in 7f454c46*) return 0;; *) return 1;; esac
-        }
-        for f in "{{ bastion_install_dir }}/bin/openshift-install" "{{ bastion_install_dir }}/bin/oc"; do
-          if [ -f "$f" ] && ! elf_hdr "$f"; then
-            rm -f "$f"
-            removed=1
-          fi
-        done
-        printf '%s' "$removed"
-      register: forge_bastion_strip_non_elf_bins
-      changed_when: forge_bastion_strip_non_elf_bins.stdout | trim == '1'
+        archive: true
+        delete: false
+        rsync_opts:
+          - "--exclude=bin/"
+          - "--exclude=.forge-download-cache/"
+      delegate_to: localhost
       tags:
         - csr_approval
         - validation
@@ -557,8 +540,7 @@
         - csr_approval
         - validation
 
-    # Sync copies controller bin/openshift-install + oc (often macOS); bastion must run Linux ELF
-    # binaries. Require both files and ELF magic — do not rely on path existence alone.
+    # Rsync excludes bin/; populate Linux openshift-install + oc from mirror below.
     - name: Decide if bastion needs Linux openshift-install and oc from mirror
       ansible.builtin.shell: |
         set -euo pipefail

--- a/playbooks/deploy_cluster.yml
+++ b/playbooks/deploy_cluster.yml
@@ -508,16 +508,18 @@
         - csr_approval
         - validation
 
-    - name: Verify rsync is available on Ansible controller (synchronize invokes local rsync)
-      ansible.builtin.stat:
-        path: "{{ item }}"
-      register: forge_controller_rsync_stat
+    - name: Resolve rsync on Ansible controller PATH (synchronize invokes local rsync)
+      ansible.builtin.command:
+        argv:
+          - bash
+          - -c
+          - command -v rsync
+      register: forge_controller_rsync_which
+      changed_when: false
+      failed_when: false
       delegate_to: localhost
       connection: local
       run_once: true
-      loop:
-        - /usr/bin/rsync
-        - /bin/rsync
       tags:
         - csr_approval
         - validation
@@ -525,10 +527,11 @@
     - name: Require rsync on Ansible controller for synchronize
       ansible.builtin.assert:
         that:
-          - forge_controller_rsync_stat.results | selectattr('stat.exists', 'equalto', true) | list | length > 0
+          - forge_controller_rsync_which.rc | default(1) | int == 0
+          - forge_controller_rsync_which.stdout | default('') | trim | length > 0
         fail_msg: >-
           rsync is required on the Ansible controller for ansible.posix.synchronize (install rsync on this machine).
-          Examples: dnf install rsync / apt install rsync; macOS includes /usr/bin/rsync by default.
+          Examples: dnf install rsync / apt install rsync / brew install rsync; macOS often ships /usr/bin/rsync.
       tags:
         - csr_approval
         - validation
@@ -543,7 +546,10 @@
         dest: "{{ bastion_install_dir }}/"
         archive: true
         delete: false
-        times: false
+        # Keep mtimes so rsync quick-check stays idempotent. With ansible.cfg become=True the remote
+        # rsync --server runs as root; owner/group false prevents chown to the controller's uid/gid.
+        owner: false
+        group: false
         # delegate_to: localhost uses a local connection; rsync's ssh must get the bastion key explicitly.
         # Relative paths must be absolute: rsync's subprocess cwd is not the project directory (ssh -i would fail).
         private_key: >-
@@ -610,7 +616,8 @@
         - csr_approval
         - validation
 
-    # Rsync excludes bin/; populate Linux openshift-install + oc from mirror below.
+    # Rsync excludes bin/, but ELF checks remain: leftover non-Linux binaries from older runs (before
+    # --exclude=bin/) or a partial download must still trigger a re-fetch from the mirror.
     - name: Decide if bastion needs Linux openshift-install and oc from mirror
       ansible.builtin.shell: |
         set -euo pipefail
@@ -723,7 +730,7 @@
       vars:
         ignition_oc_mirror_target_bin_dir: "{{ bastion_install_dir }}/bin"
         ignition_oc_mirror_download_tmp: "/var/tmp/gryphon-forge-oc-mirror-dl-{{ cluster_name }}"
-      when: forge_oc_mirror_install_enabled | default(true) | bool
+      when: forge_oc_mirror_install_enabled | default(false) | bool
       tags:
         - csr_approval
         - validation

--- a/playbooks/deploy_cluster.yml
+++ b/playbooks/deploy_cluster.yml
@@ -458,8 +458,8 @@
     # Use /var/tmp to avoid /tmp space limits (openshift-install tarball ~395MB)
     forge_bastion_tmp: "/var/tmp/gryphon-forge-ocp-tools"
   tasks:
-    # ansible.cfg often sets become=true globally; directories created as root break synchronize because
-    # rsync over SSH runs as ansible_user (ec2-user), not root.
+    # Rsync over SSH runs as ansible_user; install_dir must be writable by that user. Use become so root
+    # can create or chown paths that still belong to root from older playbook runs (ec2-user alone cannot).
     - name: Ensure bastion install directory exists
       ansible.builtin.file:
         path: "{{ bastion_install_dir }}"
@@ -467,7 +467,7 @@
         mode: "0755"
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
-      become: false
+      become: true
       tags:
         - csr_approval
         - validation
@@ -479,12 +479,12 @@
         mode: "0755"
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
-      become: false
+      become: true
       tags:
         - csr_approval
         - validation
 
-    # Repair root:root trees from older runs (copy/become) so ec2-user can rsync into this path.
+    # Descendants may still be root-owned from partial runs; recurse fixes the full tree for rsync.
     - name: Align ownership on bastion install dir for synchronize SSH user
       ansible.builtin.file:
         path: "{{ bastion_install_dir }}"

--- a/playbooks/deploy_cluster.yml
+++ b/playbooks/deploy_cluster.yml
@@ -497,8 +497,8 @@
         - csr_approval
         - validation
 
-    # ansible.posix.synchronize runs rsync on the controller and invokes rsync --server on the bastion over SSH.
-    # Minimal AMIs often omit rsync; install before sync.
+    # ansible.posix.synchronize runs rsync on the Ansible controller and rsync --server on the bastion over SSH.
+    # Minimal AMIs often omit rsync; install on bastion before sync. Controllers usually ship rsync (verify below).
     - name: Ensure rsync is installed on bastion (remote rsync helper for synchronize)
       ansible.builtin.package:
         name: rsync
@@ -508,10 +508,36 @@
         - csr_approval
         - validation
 
+    - name: Verify rsync is available on Ansible controller (synchronize invokes local rsync)
+      ansible.builtin.stat:
+        path: "{{ item }}"
+      register: forge_controller_rsync_stat
+      delegate_to: localhost
+      connection: local
+      run_once: true
+      loop:
+        - /usr/bin/rsync
+        - /bin/rsync
+      tags:
+        - csr_approval
+        - validation
+
+    - name: Require rsync on Ansible controller for synchronize
+      ansible.builtin.assert:
+        that:
+          - forge_controller_rsync_stat.results | selectattr('stat.exists', 'equalto', true) | list | length > 0
+        fail_msg: >-
+          rsync is required on the Ansible controller for ansible.posix.synchronize (install rsync on this machine).
+          Examples: dnf install rsync / apt install rsync; macOS includes /usr/bin/rsync by default.
+      tags:
+        - csr_approval
+        - validation
+
     - name: Rsync install artifacts to bastion (exclude controller bin and download cache)
       vars:
         # Raw path from inventory / -e (may be relative to where ansible-playbook was started).
         _forge_bastion_pk: "{{ hostvars[inventory_hostname]['ansible_ssh_private_key_file'] | default(bastion_ssh_private_key_path, true) }}"
+        _forge_bastion_pk_expanded: "{{ _forge_bastion_pk | expanduser }}"
       ansible.posix.synchronize:
         src: "{{ forge_controller_install_dir | expanduser }}/"
         dest: "{{ bastion_install_dir }}/"
@@ -522,11 +548,9 @@
         # Relative paths must be absolute: rsync's subprocess cwd is not the project directory (ssh -i would fail).
         private_key: >-
           {{
-            (
-              ((playbook_dir | dirname) ~ '/' ~ (_forge_bastion_pk | expanduser))
-              if (_forge_bastion_pk | expanduser | regex_search('^/')) is none
-              else (_forge_bastion_pk | expanduser)
-            ) | normpath
+            (_forge_bastion_pk_expanded | normpath)
+            if (_forge_bastion_pk_expanded | regex_search('^/'))
+            else ([playbook_dir | dirname, _forge_bastion_pk_expanded] | path_join | normpath)
           }}
         rsync_opts:
           - "--exclude=bin/"

--- a/playbooks/deploy_cluster.yml
+++ b/playbooks/deploy_cluster.yml
@@ -477,11 +477,24 @@
         - validation
 
     - name: Rsync install artifacts to bastion (exclude controller bin and download cache)
+      vars:
+        # Raw path from inventory / -e (may be relative to where ansible-playbook was started).
+        _forge_bastion_pk: "{{ hostvars[inventory_hostname]['ansible_ssh_private_key_file'] | default(bastion_ssh_private_key_path, true) }}"
       ansible.posix.synchronize:
         src: "{{ forge_controller_install_dir | expanduser }}/"
         dest: "{{ bastion_install_dir }}/"
         archive: true
         delete: false
+        # delegate_to: localhost uses a local connection; rsync's ssh must get the bastion key explicitly.
+        # Relative paths must be absolute: rsync's subprocess cwd is not the project directory (ssh -i would fail).
+        private_key: >-
+          {{
+            (
+              ((playbook_dir | dirname) ~ '/' ~ (_forge_bastion_pk | expanduser))
+              if (_forge_bastion_pk | expanduser | regex_search('^/')) is none
+              else (_forge_bastion_pk | expanduser)
+            ) | normpath
+          }}
         rsync_opts:
           - "--exclude=bin/"
           - "--exclude=.forge-download-cache/"

--- a/playbooks/deploy_cluster.yml
+++ b/playbooks/deploy_cluster.yml
@@ -483,6 +483,30 @@
         - csr_approval
         - validation
 
+    # Copy brings controller bin/oc + openshift-install (often macOS from a Darwin laptop). Remove anything
+    # that is not Linux ELF so the next task re-fetches Linux bits from the mirror.
+    - name: Remove non-ELF openshift-install and oc after controller copy (Darwin controller → Linux bastion)
+      ansible.builtin.shell: |
+        set -euo pipefail
+        removed=0
+        elf_hdr() {
+          [ -f "$1" ] || return 1
+          h=$(head -c 4 "$1" | od -An -t x1 | tr -d '[:space:]')
+          case "$h" in 7f454c46*) return 0;; *) return 1;; esac
+        }
+        for f in "{{ bastion_install_dir }}/bin/openshift-install" "{{ bastion_install_dir }}/bin/oc"; do
+          if [ -f "$f" ] && ! elf_hdr "$f"; then
+            rm -f "$f"
+            removed=1
+          fi
+        done
+        printf '%s' "$removed"
+      register: forge_bastion_strip_non_elf_bins
+      changed_when: forge_bastion_strip_non_elf_bins.stdout | trim == '1'
+      tags:
+        - csr_approval
+        - validation
+
     # Bastion SSH uses bastion_ssh_private_key_path (ec2-user). Bootstrap/RHCOS core uses the key
     # embedded in install-config (ssh_public_key_path); copy its private half for gather / manual SSH.
     - name: Stat OCP SSH private key on Ansible controller

--- a/playbooks/install_rhoai.yml
+++ b/playbooks/install_rhoai.yml
@@ -1,0 +1,104 @@
+---
+# Install Red Hat OpenShift AI (RHOAI) on an existing Gryphon Forge cluster.
+#
+# Prerequisites:
+#   - Cluster deployed and validated (playbooks/deploy_cluster.yml)
+#   - For disconnected: RHOAI operators/images mirrored (scripts/mirror-rhoai.sh)
+#     and optionally apply with -e rhoai_apply_mirror_resources=true
+#
+# Example:
+#   ansible-playbook playbooks/install_rhoai.yml -i inventory/hosts.yml \
+#     -e @../gryphon-foundry/foundry_output.json \
+#     -e foundry_output_path=../gryphon-foundry/foundry_output.json \
+#     -e bastion_ssh_private_key_path=../gryphon-foundry/bastion-key.pem \
+#     -e rhoai_channel=stable-3.4
+#
+# Tags: prep, storage, mirror_resources, operators, dsc, verify, rhoai
+
+- name: Load foundry outputs for RHOAI install
+  hosts: local
+  gather_facts: true
+  tasks:
+    - name: Check if foundry output exists
+      ansible.builtin.stat:
+        path: "{{ foundry_output_path | expanduser }}"
+      register: foundry_output_stat
+      tags:
+        - always
+
+    - name: Load foundry_output.json if present
+      ansible.builtin.include_vars:
+        file: "{{ foundry_output_path | expanduser }}"
+        name: foundry
+      when: foundry_output_stat.stat.exists | default(false)
+      tags:
+        - always
+
+    - name: Override with foundry outputs (RHOAI subset)
+      ansible.builtin.set_fact:
+        foundry_bastion_host: >-
+          {{ (((foundry | default({})).bastion_public_ip | default(bastion_public_ip)) | default({}))['value']
+          | default((((foundry | default({})).bastion_public_dns | default(bastion_public_dns)) | default({}))['value'])
+          | default((foundry | default({})).bastion_public_ip | default(bastion_public_ip))
+          | default((foundry | default({})).bastion_public_dns | default(bastion_public_dns))
+          | default('') }}
+        foundry_base_domain: >-
+          {{ (((foundry | default({})).ocp_base_domain | default(ocp_base_domain)) | default({}))['value']
+          | default((foundry | default({})).ocp_base_domain | default(ocp_base_domain) | default('')) }}
+        foundry_cluster_name: >-
+          {{ (((foundry | default({})).ocp_cluster_name | default(ocp_cluster_name)) | default({}))['value']
+          | default((foundry | default({})).ocp_cluster_name | default(ocp_cluster_name) | default('')) }}
+        mirror_registry_url: >-
+          {{ ((foundry | default({})).mirror_registry_url | default({}))['value']
+          | default((foundry | default({})).mirror_registry_url | default(mirror_registry_url) | default('')) }}
+        mirror_registry_additional_trust_bundle: >-
+          {{
+            (
+              ((foundry | default({})).mirror_registry_additional_trust_bundle | default({}))['value']
+              | default((foundry | default({})).mirror_registry_additional_trust_bundle
+              | default(mirror_registry_additional_trust_bundle) | default(''), true)
+            )
+            | default('', true)
+          }}
+      tags:
+        - always
+
+    - name: Apply foundry cluster identity overrides
+      ansible.builtin.set_fact:
+        cluster_name: "{{ foundry_cluster_name if (foundry_cluster_name | length > 0) else cluster_name }}"
+        base_domain: "{{ foundry_base_domain if (foundry_base_domain | length > 0) else base_domain }}"
+      tags:
+        - always
+
+    - name: Add bastion to inventory for API access
+      ansible.builtin.add_host:
+        name: bastion
+        groups: bastion
+        ansible_host: "{{ foundry_bastion_host }}"
+        ansible_user: "{{ bastion_ssh_user }}"
+        ansible_connection: ssh
+        ansible_ssh_private_key_file: "{{ bastion_ssh_private_key_path | expanduser }}"
+        ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+      when: foundry_bastion_host is defined and foundry_bastion_host | length > 0
+      tags:
+        - always
+
+- name: Install RHOAI
+  hosts: "{{ 'bastion' if ((hostvars['localhost'] | default({})).get('foundry_bastion_host', '') | length > 0) else 'local' }}"
+  gather_facts: true
+  vars:
+    cluster_name: "{{ hostvars['localhost']['cluster_name'] }}"
+    base_domain: "{{ hostvars['localhost']['base_domain'] }}"
+    forge_api_install_dir: "{{ bastion_install_dir if ((hostvars['localhost'] | default({})).get('foundry_bastion_host', '') | length > 0) else install_dir }}"
+    forge_use_bastion_bins: "{{ (hostvars['localhost'] | default({})).get('foundry_bastion_host', '') | length > 0 }}"
+  roles:
+    - role: rhoai
+      vars:
+        rhoai_install_dir: "{{ forge_api_install_dir }}"
+        rhoai_controller_install_dir: "{{ install_dir }}"
+        rhoai_oc_cmd: >-
+          {{ forge_api_install_dir ~ '/bin/oc' if forge_use_bastion_bins
+             else (hostvars['localhost']['openshift_client_cmd'] | default('oc')) }}
+        rhoai_mirror_ca_pem: "{{ hostvars['localhost']['mirror_registry_additional_trust_bundle'] | default('', true) }}"
+      tags:
+        - rhoai

--- a/playbooks/preflight.yml
+++ b/playbooks/preflight.yml
@@ -127,6 +127,21 @@
         hosted_zone_id: "{{ preflight_zone_id }}"
         region: "{{ preflight_region }}"
       register: preflight_route53_zone
+      # amazon.aws rejects profile + explicit credentials in the same call. A shell may have both
+      # AWS_PROFILE (e.g. default) and AWS_* key/session env vars; clear profile for this task only.
+      environment: "{{ _preflight_r53_env }}"
+      vars:
+        _preflight_r53_env: >-
+          {{
+            {'AWS_PROFILE': ''}
+            if (
+              (lookup('env', 'AWS_ACCESS_KEY_ID', default='') | length > 0)
+              or (lookup('env', 'AWS_ACCESS_KEY', default='') | length > 0)
+              or (lookup('env', 'AWS_SECRET_ACCESS_KEY', default='') | length > 0)
+              or (lookup('env', 'AWS_SESSION_TOKEN', default='') | length > 0)
+            )
+            else {}
+          }}
 
     - name: Derive VPC IDs associated with internal hosted zone
       ansible.builtin.set_fact:

--- a/playbooks/preflight.yml
+++ b/playbooks/preflight.yml
@@ -120,18 +120,9 @@
         - preflight_ocp_cluster_name | default('') | length > 0
         - preflight_ocp_base_domain | default('') | length > 0
 
-    - name: Fetch Route53 private zone details (VPC association for Vault resolver)
-      amazon.aws.route53_info:
-        query: hosted_zone
-        hosted_zone_method: details
-        hosted_zone_id: "{{ preflight_zone_id }}"
-        region: "{{ preflight_region }}"
-      register: preflight_route53_zone
-      # amazon.aws rejects profile + explicit credentials in the same call. A shell may have both
-      # AWS_PROFILE (e.g. default) and AWS_* key/session env vars; clear profile for this task only.
-      environment: "{{ _preflight_r53_env }}"
-      vars:
-        _preflight_r53_env: >-
+    - name: Resolve Route53 credential environment for preflight
+      ansible.builtin.set_fact:
+        preflight_r53_env: >-
           {{
             {'AWS_PROFILE': ''}
             if (
@@ -142,6 +133,25 @@
             )
             else {}
           }}
+
+    - name: Debug which AWS credential source preflight Route53 will use
+      ansible.builtin.debug:
+        msg: >-
+          Route53 GetHostedZone using
+          {{ 'explicit AWS_* env credentials (AWS_PROFILE cleared for this call)'
+             if (preflight_r53_env | length > 0)
+             else 'default credential chain (profile / instance role / shared config)' }}.
+
+    - name: Fetch Route53 private zone details (VPC association for Vault resolver)
+      amazon.aws.route53_info:
+        query: hosted_zone
+        hosted_zone_method: details
+        hosted_zone_id: "{{ preflight_zone_id }}"
+        region: "{{ preflight_region }}"
+      register: preflight_route53_zone
+      # amazon.aws rejects profile + explicit credentials in the same call. A shell may have both
+      # AWS_PROFILE (e.g. default) and AWS_* key/session env vars; clear profile for this task only.
+      environment: "{{ preflight_r53_env }}"
 
     - name: Derive VPC IDs associated with internal hosted zone
       ansible.builtin.set_fact:

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,8 @@
 ---
 # Ansible Galaxy collections required by Gryphon Forge
 collections:
+  - name: ansible.posix
+    version: ">=1.5.0"
   - name: amazon.aws
     version: ">=7.0.0"
   - name: community.aws

--- a/roles/aws_nodes/README.md
+++ b/roles/aws_nodes/README.md
@@ -22,7 +22,8 @@ Provisions EC2 instances, internal Load Balancers (NLB/ALB), and Route53 DNS rec
 | `rhcos_ami_source_region` | Source region for AMI copy | `foundry_region` when empty |
 | `master_count` | Number of control plane nodes | 3 |
 | `worker_count` | Number of worker nodes | 3 |
-| `gpu_worker_count` | Number of GPU worker nodes | 1 |
+| `gpu_worker_count` | Number of GPU worker nodes | 3 |
+| `gpu_worker_instance_type` | GPU worker instance type (default `g6.4xlarge` for RHOAI) | `g6.4xlarge` |
 | `aws_nodes_lb_target_discovery_retries` | EC2 describe retries when registering NLB targets (`--tags load_balancers`) | 40 |
 | `aws_nodes_lb_target_discovery_delay` | Seconds between retries | 8 |
 | `aws_nodes_lb_prune_api_mcs_targets_enabled` | After API/MCS registration, run prune logic for `{{ cluster_name }}-api-tg` / `-mcs-tg` | `true` |

--- a/roles/aws_nodes/defaults/main.yml
+++ b/roles/aws_nodes/defaults/main.yml
@@ -36,7 +36,7 @@ aws_nodes_lb_prune_api_mcs_foreign_cluster_targets: true
 aws_nodes_ingress_register_masters_when_no_workers: true
 
 # Route53 oauth-openshift.apps and API NLB :443 oauth-tg (coupled to ignition_oauth_apps_api_named_certificate via forge_oauth_apps_via_api_nlb). Issue #30.
-aws_nodes_oauth_apps_alias_api_nlb: "{{ forge_oauth_apps_via_api_nlb | default((ocp_version | default('4.14')) is version('4.21', '<')) }}"
+aws_nodes_oauth_apps_alias_api_nlb: "{{ forge_oauth_apps_via_api_nlb | default((ocp_version | default('4.14')) is version('4.21', '<')) | bool }}"
 
 # Before worker/GPU EC2: assert api/api-int exist in foundry_internal_hosted_zone_id and the zone is associated with foundry_vpc_id
 aws_nodes_dns_gate_enabled: true

--- a/roles/aws_nodes/tasks/ec2_control_plane.yml
+++ b/roles/aws_nodes/tasks/ec2_control_plane.yml
@@ -169,7 +169,7 @@
           delete_on_termination: true
     tags: "{{ aws_nodes_ec2_kubernetes_cluster_tags | combine({'Name': aws_nodes_instance_name_tag, 'cluster': cluster_name, 'role': 'master'}) }}"
     state: present
-  loop: "{{ range(0, master_count) | list }}"
+  loop: "{{ range(0, master_count | int) | list }}"
   register: aws_nodes_master_launch
   tags:
     - aws_nodes

--- a/roles/aws_nodes/tasks/ec2_workers.yml
+++ b/roles/aws_nodes/tasks/ec2_workers.yml
@@ -25,7 +25,7 @@
           delete_on_termination: true
     tags: "{{ aws_nodes_ec2_kubernetes_cluster_tags | combine({'Name': aws_nodes_instance_name_tag, 'cluster': cluster_name, 'role': 'worker'}) }}"
     state: present
-  loop: "{{ range(0, worker_count) | list }}"
+  loop: "{{ range(0, worker_count | int) | list }}"
   register: aws_nodes_worker_launch
   tags:
     - aws_nodes
@@ -55,7 +55,7 @@
           delete_on_termination: true
     tags: "{{ aws_nodes_ec2_kubernetes_cluster_tags | combine({'Name': aws_nodes_instance_name_tag, 'cluster': cluster_name, 'role': 'gpu-worker'}) }}"
     state: present
-  loop: "{{ range(0, gpu_worker_count | default(0)) | list }}"
+  loop: "{{ range(0, gpu_worker_count | default(0) | int) | list }}"
   when: gpu_worker_count | default(0) | int > 0
   register: aws_nodes_gpu_worker_launch
   tags:

--- a/roles/ignition/defaults/main.yml
+++ b/roles/ignition/defaults/main.yml
@@ -28,6 +28,6 @@ mirror_registry_discovery_scheme: "https"  # noqa: var-naming[no-role-prefix]
 # OCP 4.21+ defaults false (ingress DNS — issue #30). Override via forge_oauth_apps_via_api_nlb or this variable.
 # When true: generate a forge-local CA + leaf, merge CA into install-config additionalTrustBundle (policy Always), and add
 # APIServer.spec.servingCerts.namedCertificates + Secret in manifests/ (Red Hat–supported user-provided API serving certs).
-ignition_oauth_apps_api_named_certificate: "{{ forge_oauth_apps_via_api_nlb | default((ocp_version | default('4.14')) is version('4.21', '<')) }}"
+ignition_oauth_apps_api_named_certificate: "{{ forge_oauth_apps_via_api_nlb | default((ocp_version | default('4.14')) is version('4.21', '<')) | bool }}"
 ignition_oauth_apps_api_serving_secret_name: forge-oauth-apps-api-serving
 ignition_oauth_apps_api_cert_validity_days: 3650

--- a/roles/ignition/defaults/main.yml
+++ b/roles/ignition/defaults/main.yml
@@ -23,6 +23,9 @@ ignition_ingress_hostnetwork_router_replicas: ""
 mirror_registry_dockerconfig_extra_path: ""  # noqa: var-naming[no-role-prefix]
 # Registry API scheme for discover-mirror-release-tag.sh (curl /v2/.../tags/list); use http only for plain-HTTP mirrors.
 mirror_registry_discovery_scheme: "https"  # noqa: var-naming[no-role-prefix]
+# oc-mirror v2 layout: payload tags under .../release-images; art-dev/components under .../release (see inventory group_vars).
+# When unset, templates fall back to mirror_registry_release_path.
+mirror_registry_art_dev_path: ""  # noqa: var-naming[no-role-prefix]
 
 # API NLB OAuth path (issues #23/#24): kube-apiserver must present a cert valid for oauth-openshift.apps when DNS points at API :443.
 # OCP 4.21+ defaults false (ingress DNS — issue #30). Override via forge_oauth_apps_via_api_nlb or this variable.

--- a/roles/ignition/tasks/ensure_oc_mirror_install.yml
+++ b/roles/ignition/tasks/ensure_oc_mirror_install.yml
@@ -2,11 +2,11 @@
 # Install oc-mirror under ignition_oc_mirror_target_bin_dir from forge_ocp_mirror_* (same channel as openshift-install / oc).
 # Required vars: ignition_oc_mirror_target_bin_dir, ignition_oc_mirror_download_tmp
 # Optional: forge_oc_mirror_install_enabled, forge_ocp_oc_mirror_archive (empty = pick rhel8/rhel9 tarball by OS)
+#
+# When forge_ocp_oc_mirror_archive is unset: Amazon Linux 2 -> rhel8; Amazon 2023 / EL9+ / default -> rhel9.
+# Other Linux (e.g. Debian/Ubuntu controller) does not error; it defaults to rhel9. Override the archive name if needed.
 
-- name: Resolve oc-mirror archive filename (inventory override)
-  ansible.builtin.set_fact:
-    ignition_oc_mirror_archive_effective: "{{ forge_ocp_oc_mirror_archive | default('') | trim }}"
-  when: forge_ocp_oc_mirror_archive | default('') | trim | length > 0
+- name: Ensure oc-mirror binary matches the OCP mirror channel
   tags:
     - ignition
     - config
@@ -14,200 +14,115 @@
     - ec2
     - csr_approval
     - validation
+  block:
+    - name: Resolve oc-mirror archive filename (inventory override)
+      ansible.builtin.set_fact:
+        ignition_oc_mirror_archive_effective: "{{ forge_ocp_oc_mirror_archive | default('') | trim }}"
+      when: forge_ocp_oc_mirror_archive | default('') | trim | length > 0
 
-- name: Resolve oc-mirror archive filename (auto rhel8 vs rhel9)
-  ansible.builtin.set_fact:
-    ignition_oc_mirror_archive_effective: "{{ _archive }}"
-  when: forge_ocp_oc_mirror_archive | default('') | trim | length == 0
-  vars:
-    _amzn_rhel9: "{{ (ansible_facts['distribution'] == 'Amazon' and ansible_facts['distribution_major_version'] == '2023') | bool }}"
-    _amzn_rhel8: "{{ (ansible_facts['distribution'] == 'Amazon' and ansible_facts['distribution_major_version'] == '2') | bool }}"
-    _el_ge_9: >-
-      {{ (ansible_facts['os_family'] == 'RedHat'
-         and ansible_facts['distribution'] not in ['Fedora', 'Amazon']
-         and (ansible_facts['distribution_major_version'] | int | default(0)) >= 9) | bool }}
-    _archive: >-
-      {{ 'oc-mirror.rhel9.tar.gz' if (_amzn_rhel9 | bool or _el_ge_9 | bool)
-         else ('oc-mirror.rhel8.tar.gz' if (_amzn_rhel8 | bool) else 'oc-mirror.rhel9.tar.gz') }}
-  tags:
-    - ignition
-    - config
-    - aws_nodes
-    - ec2
-    - csr_approval
-    - validation
+    - name: Resolve oc-mirror archive filename (auto rhel8 vs rhel9)
+      ansible.builtin.set_fact:
+        ignition_oc_mirror_archive_effective: "{{ _archive }}"
+      when: forge_ocp_oc_mirror_archive | default('') | trim | length == 0
+      vars:
+        _dist: "{{ ansible_facts['distribution'] | default('', true) }}"
+        _dist_maj: "{{ ansible_facts['distribution_major_version'] | default('0', true) }}"
+        _os_fam: "{{ ansible_facts['os_family'] | default('', true) }}"
+        _archive: >-
+          {{ 'oc-mirror.rhel9.tar.gz'
+             if ((_dist == 'Amazon' and _dist_maj == '2023')
+                 or (_os_fam == 'RedHat' and _dist not in ['Fedora', 'Amazon'] and (_dist_maj | int) >= 9))
+             else ('oc-mirror.rhel8.tar.gz'
+                   if (_dist == 'Amazon' and _dist_maj == '2')
+                   else 'oc-mirror.rhel9.tar.gz') }}
 
-- name: Stat oc-mirror binary
-  ansible.builtin.stat:
-    path: "{{ ignition_oc_mirror_target_bin_dir }}/oc-mirror"
-  register: ignition_oc_mirror_binary_stat
-  tags:
-    - ignition
-    - config
-    - aws_nodes
-    - ec2
-    - csr_approval
-    - validation
+    - name: Stat oc-mirror binary
+      ansible.builtin.stat:
+        path: "{{ ignition_oc_mirror_target_bin_dir }}/oc-mirror"
+      register: ignition_oc_mirror_binary_stat
 
-- name: Stat oc-mirror channel marker
-  ansible.builtin.stat:
-    path: "{{ ignition_oc_mirror_target_bin_dir }}/.forge-oc-mirror-channel"
-  register: ignition_oc_mirror_marker_stat
-  tags:
-    - ignition
-    - config
-    - aws_nodes
-    - ec2
-    - csr_approval
-    - validation
+    - name: Stat oc-mirror channel marker
+      ansible.builtin.stat:
+        path: "{{ ignition_oc_mirror_target_bin_dir }}/.forge-oc-mirror-channel"
+      register: ignition_oc_mirror_marker_stat
 
-- name: Read oc-mirror channel marker
-  ansible.builtin.slurp:
-    path: "{{ ignition_oc_mirror_target_bin_dir }}/.forge-oc-mirror-channel"
-  register: ignition_oc_mirror_marker_slurp
-  when: ignition_oc_mirror_marker_stat.stat.exists | default(false)
-  tags:
-    - ignition
-    - config
-    - aws_nodes
-    - ec2
-    - csr_approval
-    - validation
+    - name: Read oc-mirror channel marker
+      ansible.builtin.slurp:
+        path: "{{ ignition_oc_mirror_target_bin_dir }}/.forge-oc-mirror-channel"
+      register: ignition_oc_mirror_marker_slurp
+      when: ignition_oc_mirror_marker_stat.stat.exists | default(false)
 
-- name: Decide whether to (re)download oc-mirror
-  ansible.builtin.set_fact:
-    ignition_oc_mirror_need_download: >-
-      {{ (not ignition_oc_mirror_binary_stat.stat.exists | default(false))
-         or (not ignition_oc_mirror_marker_stat.stat.exists | default(false))
-         or (_marker_channel_mismatch | default(false)) }}
-  vars:
-    _marker_channel_mismatch: >-
-      {{ (ignition_oc_mirror_marker_stat.stat.exists | default(false))
-         and not (ignition_oc_mirror_marker_slurp.skipped | default(false))
-         and ((ignition_oc_mirror_marker_slurp.content | b64decode | trim) != (forge_ocp_mirror_channel | trim)) }}
-  tags:
-    - ignition
-    - config
-    - aws_nodes
-    - ec2
-    - csr_approval
-    - validation
+    - name: Decide whether to (re)download oc-mirror
+      ansible.builtin.set_fact:
+        ignition_oc_mirror_need_download: >-
+          {{ (not ignition_oc_mirror_binary_stat.stat.exists | default(false))
+             or (not ignition_oc_mirror_marker_stat.stat.exists | default(false))
+             or (_marker_channel_mismatch | default(false)) }}
+      vars:
+        _marker_channel_mismatch: >-
+          {{ (ignition_oc_mirror_marker_stat.stat.exists | default(false))
+             and not (ignition_oc_mirror_marker_slurp.skipped | default(false))
+             and ((ignition_oc_mirror_marker_slurp.content | b64decode | trim) != (forge_ocp_mirror_channel | trim)) }}
 
-- name: Ensure oc-mirror download temp directory exists
-  ansible.builtin.file:
-    path: "{{ ignition_oc_mirror_download_tmp }}"
-    state: directory
-    mode: "0700"
-  when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
-  tags:
-    - ignition
-    - config
-    - aws_nodes
-    - ec2
-    - csr_approval
-    - validation
+    - name: Ensure oc-mirror download temp directory exists
+      ansible.builtin.file:
+        path: "{{ ignition_oc_mirror_download_tmp }}"
+        state: directory
+        mode: "0700"
+      when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
 
-- name: Download oc-mirror archive from OCP mirror
-  ansible.builtin.get_url:
-    url: "{{ forge_ocp_mirror_base_url }}/{{ forge_ocp_mirror_channel }}/{{ ignition_oc_mirror_archive_effective }}"
-    dest: "{{ ignition_oc_mirror_download_tmp }}/{{ ignition_oc_mirror_archive_effective }}"
-    mode: "0644"
-    validate_certs: "{{ forge_ocp_mirror_validate_certs | default(true) | bool }}"
-  when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
-  tags:
-    - ignition
-    - config
-    - aws_nodes
-    - ec2
-    - csr_approval
-    - validation
+    - name: Download oc-mirror archive from OCP mirror
+      ansible.builtin.get_url:
+        url: "{{ forge_ocp_mirror_base_url }}/{{ forge_ocp_mirror_channel }}/{{ ignition_oc_mirror_archive_effective }}"
+        dest: "{{ ignition_oc_mirror_download_tmp }}/{{ ignition_oc_mirror_archive_effective }}"
+        mode: "0644"
+        validate_certs: "{{ forge_ocp_mirror_validate_certs | default(true) | bool }}"
+      when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
 
-- name: Extract oc-mirror archive
-  ansible.builtin.unarchive:
-    src: "{{ ignition_oc_mirror_download_tmp }}/{{ ignition_oc_mirror_archive_effective }}"
-    dest: "{{ ignition_oc_mirror_download_tmp }}"
-    remote_src: true
-  when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
-  tags:
-    - ignition
-    - config
-    - aws_nodes
-    - ec2
-    - csr_approval
-    - validation
+    - name: Extract oc-mirror archive
+      ansible.builtin.unarchive:
+        src: "{{ ignition_oc_mirror_download_tmp }}/{{ ignition_oc_mirror_archive_effective }}"
+        dest: "{{ ignition_oc_mirror_download_tmp }}"
+        remote_src: true
+      when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
 
-- name: Install oc-mirror binary
-  ansible.builtin.shell: |
-    set -euo pipefail
-    BIN=$(find "{{ ignition_oc_mirror_download_tmp }}" -name 'oc-mirror' -type f 2>/dev/null | head -1)
-    if [ -z "$BIN" ]; then
-      echo "oc-mirror binary not found in archive {{ ignition_oc_mirror_archive_effective }}"
-      exit 1
-    fi
-    cp "$BIN" "{{ ignition_oc_mirror_target_bin_dir }}/oc-mirror"
-    chmod 0755 "{{ ignition_oc_mirror_target_bin_dir }}/oc-mirror"
-  when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
-  tags:
-    - ignition
-    - config
-    - aws_nodes
-    - ec2
-    - csr_approval
-    - validation
+    - name: Install oc-mirror binary
+      ansible.builtin.shell: |
+        set -euo pipefail
+        BIN=$(find "{{ ignition_oc_mirror_download_tmp }}" -name 'oc-mirror' -type f 2>/dev/null | head -1)
+        if [ -z "$BIN" ]; then
+          echo "oc-mirror binary not found in archive {{ ignition_oc_mirror_archive_effective }}"
+          exit 1
+        fi
+        cp "$BIN" "{{ ignition_oc_mirror_target_bin_dir }}/oc-mirror"
+        chmod 0755 "{{ ignition_oc_mirror_target_bin_dir }}/oc-mirror"
+      when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
 
-- name: Record oc-mirror mirror channel for idempotent refresh
-  ansible.builtin.copy:
-    dest: "{{ ignition_oc_mirror_target_bin_dir }}/.forge-oc-mirror-channel"
-    content: "{{ forge_ocp_mirror_channel }}\n"
-    mode: "0644"
-  when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
-  tags:
-    - ignition
-    - config
-    - aws_nodes
-    - ec2
-    - csr_approval
-    - validation
+    - name: Record oc-mirror mirror channel for idempotent refresh
+      ansible.builtin.copy:
+        dest: "{{ ignition_oc_mirror_target_bin_dir }}/.forge-oc-mirror-channel"
+        content: "{{ forge_ocp_mirror_channel }}\n"
+        mode: "0644"
+      when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
 
-- name: Remove oc-mirror download temp directory
-  ansible.builtin.file:
-    path: "{{ ignition_oc_mirror_download_tmp }}"
-    state: absent
-  when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
-  tags:
-    - ignition
-    - config
-    - aws_nodes
-    - ec2
-    - csr_approval
-    - validation
+    - name: Remove oc-mirror download temp directory
+      ansible.builtin.file:
+        path: "{{ ignition_oc_mirror_download_tmp }}"
+        state: absent
+      when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
 
-- name: Stat oc-mirror after ensure
-  ansible.builtin.stat:
-    path: "{{ ignition_oc_mirror_target_bin_dir }}/oc-mirror"
-  register: ignition_oc_mirror_final_stat
-  when: forge_oc_mirror_install_enabled | default(true) | bool
-  tags:
-    - ignition
-    - config
-    - aws_nodes
-    - ec2
-    - csr_approval
-    - validation
+    - name: Stat oc-mirror after ensure
+      ansible.builtin.stat:
+        path: "{{ ignition_oc_mirror_target_bin_dir }}/oc-mirror"
+      register: ignition_oc_mirror_final_stat
+      when: forge_oc_mirror_install_enabled | default(true) | bool
 
-- name: Require oc-mirror after ensure
-  ansible.builtin.assert:
-    that:
-      - ignition_oc_mirror_final_stat.stat.exists | default(false)
-      - ignition_oc_mirror_final_stat.stat.executable | default(false)
-    fail_msg: >-
-      oc-mirror missing at {{ ignition_oc_mirror_target_bin_dir }}/oc-mirror after download.
-      Check forge_ocp_mirror_base_url / forge_ocp_mirror_channel / forge_ocp_oc_mirror_archive and network access.
-  when: forge_oc_mirror_install_enabled | default(true) | bool
-  tags:
-    - ignition
-    - config
-    - aws_nodes
-    - ec2
-    - csr_approval
-    - validation
+    - name: Require oc-mirror after ensure
+      ansible.builtin.assert:
+        that:
+          - ignition_oc_mirror_final_stat.stat.exists | default(false)
+          - ignition_oc_mirror_final_stat.stat.executable | default(false)
+        fail_msg: >-
+          oc-mirror missing at {{ ignition_oc_mirror_target_bin_dir }}/oc-mirror after download.
+          Check forge_ocp_mirror_base_url / forge_ocp_mirror_channel / forge_ocp_oc_mirror_archive and network access.
+      when: forge_oc_mirror_install_enabled | default(true) | bool

--- a/roles/ignition/tasks/ensure_oc_mirror_install.yml
+++ b/roles/ignition/tasks/ensure_oc_mirror_install.yml
@@ -1,10 +1,13 @@
 ---
 # Install oc-mirror under ignition_oc_mirror_target_bin_dir from forge_ocp_mirror_* (same channel as openshift-install / oc).
 # Required vars: ignition_oc_mirror_target_bin_dir, ignition_oc_mirror_download_tmp
-# Optional: forge_oc_mirror_install_enabled, forge_ocp_oc_mirror_archive (empty = pick rhel8/rhel9 tarball by OS)
+# Optional: forge_oc_mirror_install_enabled, forge_ocp_oc_mirror_archive
 #
-# When forge_ocp_oc_mirror_archive is unset: Amazon Linux 2 -> rhel8; Amazon 2023 / EL9+ / default -> rhel9.
-# Other Linux (e.g. Debian/Ubuntu controller) does not error; it defaults to rhel9. Override the archive name if needed.
+# Archive selection when forge_ocp_oc_mirror_archive is unset:
+#   - Prefer oc-mirror.rhel9.tar.gz on EL9+ / Amazon Linux 2023 only after a HEAD probe succeeds
+#     (rhel9 tarballs exist from OCP 4.15+; older channels 404).
+#   - Otherwise use oc-mirror.tar.gz (present on all channels).
+#   - Never select oc-mirror.rhel8.tar.gz — that artifact does not exist on mirror.openshift.com.
 
 - name: Ensure oc-mirror binary matches the OCP mirror channel
   tags:
@@ -20,21 +23,50 @@
         ignition_oc_mirror_archive_effective: "{{ forge_ocp_oc_mirror_archive | default('') | trim }}"
       when: forge_ocp_oc_mirror_archive | default('') | trim | length > 0
 
-    - name: Resolve oc-mirror archive filename (auto rhel8 vs rhel9)
+    - name: Decide whether to prefer oc-mirror.rhel9.tar.gz for this host
       ansible.builtin.set_fact:
-        ignition_oc_mirror_archive_effective: "{{ _archive }}"
+        ignition_oc_mirror_prefer_rhel9: >-
+          {{
+            (_dist == 'Amazon' and _dist_maj == '2023')
+            or (_os_fam == 'RedHat' and _dist not in ['Fedora', 'Amazon'] and (_dist_maj | int) >= 9)
+          }}
       when: forge_ocp_oc_mirror_archive | default('') | trim | length == 0
       vars:
         _dist: "{{ ansible_facts['distribution'] | default('', true) }}"
         _dist_maj: "{{ ansible_facts['distribution_major_version'] | default('0', true) }}"
         _os_fam: "{{ ansible_facts['os_family'] | default('', true) }}"
-        _archive: >-
-          {{ 'oc-mirror.rhel9.tar.gz'
-             if ((_dist == 'Amazon' and _dist_maj == '2023')
-                 or (_os_fam == 'RedHat' and _dist not in ['Fedora', 'Amazon'] and (_dist_maj | int) >= 9))
-             else ('oc-mirror.rhel8.tar.gz'
-                   if (_dist == 'Amazon' and _dist_maj == '2')
-                   else 'oc-mirror.rhel9.tar.gz') }}
+
+    - name: HEAD probe oc-mirror.rhel9.tar.gz on the OCP mirror channel
+      ansible.builtin.uri:
+        url: "{{ forge_ocp_mirror_base_url }}/{{ forge_ocp_mirror_channel }}/oc-mirror.rhel9.tar.gz"
+        method: HEAD
+        status_code: [200, 404]
+        validate_certs: "{{ forge_ocp_mirror_validate_certs | default(true) | bool }}"
+      register: ignition_oc_mirror_rhel9_head
+      changed_when: false
+      when:
+        - forge_ocp_oc_mirror_archive | default('') | trim | length == 0
+        - ignition_oc_mirror_prefer_rhel9 | default(false) | bool
+
+    - name: Resolve oc-mirror archive filename (universal tarball with optional rhel9)
+      ansible.builtin.set_fact:
+        ignition_oc_mirror_archive_effective: >-
+          {{
+            'oc-mirror.rhel9.tar.gz'
+            if (
+              (ignition_oc_mirror_prefer_rhel9 | default(false) | bool)
+              and (ignition_oc_mirror_rhel9_head.status | default(404) | int == 200)
+            )
+            else 'oc-mirror.tar.gz'
+          }}
+      when: forge_ocp_oc_mirror_archive | default('') | trim | length == 0
+
+    - name: Ensure oc-mirror target bin directory exists
+      ansible.builtin.file:
+        path: "{{ ignition_oc_mirror_target_bin_dir }}"
+        state: directory
+        mode: "0755"
+      when: forge_oc_mirror_install_enabled | default(false) | bool
 
     - name: Stat oc-mirror binary
       ansible.builtin.stat:
@@ -69,7 +101,7 @@
         path: "{{ ignition_oc_mirror_download_tmp }}"
         state: directory
         mode: "0700"
-      when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
+      when: forge_oc_mirror_install_enabled | default(false) | bool and ignition_oc_mirror_need_download | bool
 
     - name: Download oc-mirror archive from OCP mirror
       ansible.builtin.get_url:
@@ -77,14 +109,14 @@
         dest: "{{ ignition_oc_mirror_download_tmp }}/{{ ignition_oc_mirror_archive_effective }}"
         mode: "0644"
         validate_certs: "{{ forge_ocp_mirror_validate_certs | default(true) | bool }}"
-      when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
+      when: forge_oc_mirror_install_enabled | default(false) | bool and ignition_oc_mirror_need_download | bool
 
     - name: Extract oc-mirror archive
       ansible.builtin.unarchive:
         src: "{{ ignition_oc_mirror_download_tmp }}/{{ ignition_oc_mirror_archive_effective }}"
         dest: "{{ ignition_oc_mirror_download_tmp }}"
         remote_src: true
-      when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
+      when: forge_oc_mirror_install_enabled | default(false) | bool and ignition_oc_mirror_need_download | bool
 
     - name: Install oc-mirror binary
       ansible.builtin.shell: |
@@ -96,26 +128,26 @@
         fi
         cp "$BIN" "{{ ignition_oc_mirror_target_bin_dir }}/oc-mirror"
         chmod 0755 "{{ ignition_oc_mirror_target_bin_dir }}/oc-mirror"
-      when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
+      when: forge_oc_mirror_install_enabled | default(false) | bool and ignition_oc_mirror_need_download | bool
 
     - name: Record oc-mirror mirror channel for idempotent refresh
       ansible.builtin.copy:
         dest: "{{ ignition_oc_mirror_target_bin_dir }}/.forge-oc-mirror-channel"
         content: "{{ forge_ocp_mirror_channel }}\n"
         mode: "0644"
-      when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
+      when: forge_oc_mirror_install_enabled | default(false) | bool and ignition_oc_mirror_need_download | bool
 
     - name: Remove oc-mirror download temp directory
       ansible.builtin.file:
         path: "{{ ignition_oc_mirror_download_tmp }}"
         state: absent
-      when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
+      when: forge_oc_mirror_install_enabled | default(false) | bool and ignition_oc_mirror_need_download | bool
 
     - name: Stat oc-mirror after ensure
       ansible.builtin.stat:
         path: "{{ ignition_oc_mirror_target_bin_dir }}/oc-mirror"
       register: ignition_oc_mirror_final_stat
-      when: forge_oc_mirror_install_enabled | default(true) | bool
+      when: forge_oc_mirror_install_enabled | default(false) | bool
 
     - name: Require oc-mirror after ensure
       ansible.builtin.assert:
@@ -123,6 +155,7 @@
           - ignition_oc_mirror_final_stat.stat.exists | default(false)
           - ignition_oc_mirror_final_stat.stat.executable | default(false)
         fail_msg: >-
-          oc-mirror missing at {{ ignition_oc_mirror_target_bin_dir }}/oc-mirror after download.
+          oc-mirror missing at {{ ignition_oc_mirror_target_bin_dir }}/oc-mirror after download
+          (tried {{ ignition_oc_mirror_archive_effective | default('?') }}).
           Check forge_ocp_mirror_base_url / forge_ocp_mirror_channel / forge_ocp_oc_mirror_archive and network access.
-      when: forge_oc_mirror_install_enabled | default(true) | bool
+      when: forge_oc_mirror_install_enabled | default(false) | bool

--- a/roles/ignition/tasks/ensure_oc_mirror_install.yml
+++ b/roles/ignition/tasks/ensure_oc_mirror_install.yml
@@ -1,0 +1,213 @@
+---
+# Install oc-mirror under ignition_oc_mirror_target_bin_dir from forge_ocp_mirror_* (same channel as openshift-install / oc).
+# Required vars: ignition_oc_mirror_target_bin_dir, ignition_oc_mirror_download_tmp
+# Optional: forge_oc_mirror_install_enabled, forge_ocp_oc_mirror_archive (empty = pick rhel8/rhel9 tarball by OS)
+
+- name: Resolve oc-mirror archive filename (inventory override)
+  ansible.builtin.set_fact:
+    ignition_oc_mirror_archive_effective: "{{ forge_ocp_oc_mirror_archive | default('') | trim }}"
+  when: forge_ocp_oc_mirror_archive | default('') | trim | length > 0
+  tags:
+    - ignition
+    - config
+    - aws_nodes
+    - ec2
+    - csr_approval
+    - validation
+
+- name: Resolve oc-mirror archive filename (auto rhel8 vs rhel9)
+  ansible.builtin.set_fact:
+    ignition_oc_mirror_archive_effective: "{{ _archive }}"
+  when: forge_ocp_oc_mirror_archive | default('') | trim | length == 0
+  vars:
+    _amzn_rhel9: "{{ (ansible_facts['distribution'] == 'Amazon' and ansible_facts['distribution_major_version'] == '2023') | bool }}"
+    _amzn_rhel8: "{{ (ansible_facts['distribution'] == 'Amazon' and ansible_facts['distribution_major_version'] == '2') | bool }}"
+    _el_ge_9: >-
+      {{ (ansible_facts['os_family'] == 'RedHat'
+         and ansible_facts['distribution'] not in ['Fedora', 'Amazon']
+         and (ansible_facts['distribution_major_version'] | int | default(0)) >= 9) | bool }}
+    _archive: >-
+      {{ 'oc-mirror.rhel9.tar.gz' if (_amzn_rhel9 | bool or _el_ge_9 | bool)
+         else ('oc-mirror.rhel8.tar.gz' if (_amzn_rhel8 | bool) else 'oc-mirror.rhel9.tar.gz') }}
+  tags:
+    - ignition
+    - config
+    - aws_nodes
+    - ec2
+    - csr_approval
+    - validation
+
+- name: Stat oc-mirror binary
+  ansible.builtin.stat:
+    path: "{{ ignition_oc_mirror_target_bin_dir }}/oc-mirror"
+  register: ignition_oc_mirror_binary_stat
+  tags:
+    - ignition
+    - config
+    - aws_nodes
+    - ec2
+    - csr_approval
+    - validation
+
+- name: Stat oc-mirror channel marker
+  ansible.builtin.stat:
+    path: "{{ ignition_oc_mirror_target_bin_dir }}/.forge-oc-mirror-channel"
+  register: ignition_oc_mirror_marker_stat
+  tags:
+    - ignition
+    - config
+    - aws_nodes
+    - ec2
+    - csr_approval
+    - validation
+
+- name: Read oc-mirror channel marker
+  ansible.builtin.slurp:
+    path: "{{ ignition_oc_mirror_target_bin_dir }}/.forge-oc-mirror-channel"
+  register: ignition_oc_mirror_marker_slurp
+  when: ignition_oc_mirror_marker_stat.stat.exists | default(false)
+  tags:
+    - ignition
+    - config
+    - aws_nodes
+    - ec2
+    - csr_approval
+    - validation
+
+- name: Decide whether to (re)download oc-mirror
+  ansible.builtin.set_fact:
+    ignition_oc_mirror_need_download: >-
+      {{ (not ignition_oc_mirror_binary_stat.stat.exists | default(false))
+         or (not ignition_oc_mirror_marker_stat.stat.exists | default(false))
+         or (_marker_channel_mismatch | default(false)) }}
+  vars:
+    _marker_channel_mismatch: >-
+      {{ (ignition_oc_mirror_marker_stat.stat.exists | default(false))
+         and not (ignition_oc_mirror_marker_slurp.skipped | default(false))
+         and ((ignition_oc_mirror_marker_slurp.content | b64decode | trim) != (forge_ocp_mirror_channel | trim)) }}
+  tags:
+    - ignition
+    - config
+    - aws_nodes
+    - ec2
+    - csr_approval
+    - validation
+
+- name: Ensure oc-mirror download temp directory exists
+  ansible.builtin.file:
+    path: "{{ ignition_oc_mirror_download_tmp }}"
+    state: directory
+    mode: "0700"
+  when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
+  tags:
+    - ignition
+    - config
+    - aws_nodes
+    - ec2
+    - csr_approval
+    - validation
+
+- name: Download oc-mirror archive from OCP mirror
+  ansible.builtin.get_url:
+    url: "{{ forge_ocp_mirror_base_url }}/{{ forge_ocp_mirror_channel }}/{{ ignition_oc_mirror_archive_effective }}"
+    dest: "{{ ignition_oc_mirror_download_tmp }}/{{ ignition_oc_mirror_archive_effective }}"
+    mode: "0644"
+    validate_certs: "{{ forge_ocp_mirror_validate_certs | default(true) | bool }}"
+  when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
+  tags:
+    - ignition
+    - config
+    - aws_nodes
+    - ec2
+    - csr_approval
+    - validation
+
+- name: Extract oc-mirror archive
+  ansible.builtin.unarchive:
+    src: "{{ ignition_oc_mirror_download_tmp }}/{{ ignition_oc_mirror_archive_effective }}"
+    dest: "{{ ignition_oc_mirror_download_tmp }}"
+    remote_src: true
+  when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
+  tags:
+    - ignition
+    - config
+    - aws_nodes
+    - ec2
+    - csr_approval
+    - validation
+
+- name: Install oc-mirror binary
+  ansible.builtin.shell: |
+    set -euo pipefail
+    BIN=$(find "{{ ignition_oc_mirror_download_tmp }}" -name 'oc-mirror' -type f 2>/dev/null | head -1)
+    if [ -z "$BIN" ]; then
+      echo "oc-mirror binary not found in archive {{ ignition_oc_mirror_archive_effective }}"
+      exit 1
+    fi
+    cp "$BIN" "{{ ignition_oc_mirror_target_bin_dir }}/oc-mirror"
+    chmod 0755 "{{ ignition_oc_mirror_target_bin_dir }}/oc-mirror"
+  when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
+  tags:
+    - ignition
+    - config
+    - aws_nodes
+    - ec2
+    - csr_approval
+    - validation
+
+- name: Record oc-mirror mirror channel for idempotent refresh
+  ansible.builtin.copy:
+    dest: "{{ ignition_oc_mirror_target_bin_dir }}/.forge-oc-mirror-channel"
+    content: "{{ forge_ocp_mirror_channel }}\n"
+    mode: "0644"
+  when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
+  tags:
+    - ignition
+    - config
+    - aws_nodes
+    - ec2
+    - csr_approval
+    - validation
+
+- name: Remove oc-mirror download temp directory
+  ansible.builtin.file:
+    path: "{{ ignition_oc_mirror_download_tmp }}"
+    state: absent
+  when: forge_oc_mirror_install_enabled | default(true) | bool and ignition_oc_mirror_need_download | bool
+  tags:
+    - ignition
+    - config
+    - aws_nodes
+    - ec2
+    - csr_approval
+    - validation
+
+- name: Stat oc-mirror after ensure
+  ansible.builtin.stat:
+    path: "{{ ignition_oc_mirror_target_bin_dir }}/oc-mirror"
+  register: ignition_oc_mirror_final_stat
+  when: forge_oc_mirror_install_enabled | default(true) | bool
+  tags:
+    - ignition
+    - config
+    - aws_nodes
+    - ec2
+    - csr_approval
+    - validation
+
+- name: Require oc-mirror after ensure
+  ansible.builtin.assert:
+    that:
+      - ignition_oc_mirror_final_stat.stat.exists | default(false)
+      - ignition_oc_mirror_final_stat.stat.executable | default(false)
+    fail_msg: >-
+      oc-mirror missing at {{ ignition_oc_mirror_target_bin_dir }}/oc-mirror after download.
+      Check forge_ocp_mirror_base_url / forge_ocp_mirror_channel / forge_ocp_oc_mirror_archive and network access.
+  when: forge_oc_mirror_install_enabled | default(true) | bool
+  tags:
+    - ignition
+    - config
+    - aws_nodes
+    - ec2
+    - csr_approval
+    - validation

--- a/roles/ignition/tasks/ensure_oc_on_bastion_for_mirror_check.yml
+++ b/roles/ignition/tasks/ensure_oc_on_bastion_for_mirror_check.yml
@@ -1,6 +1,6 @@
 ---
 # Ensure Linux oc exists under bastion_install_dir/bin for mirror digest preflight (client tarball only).
-# Controller may be macOS: sync or prior runs can leave Mach-O binaries; existence alone is not enough.
+# Rsync excludes bin/; this path still catches a missing binary or a leftover non-ELF (e.g. pre-exclude Mach-O) copy.
 - name: Check whether bastion oc is missing or not Linux ELF
   ansible.builtin.shell: |
     set -euo pipefail
@@ -12,7 +12,8 @@
     case "$h" in 7f454c46*) exit 0;; *) exit 1;; esac
   register: ignition_oc_on_bastion_elf_check
   changed_when: false
-  failed_when: false
+  # 0=ELF, 1=not ELF, 2=missing — any other rc is unexpected (permissions, missing od, etc.)
+  failed_when: ignition_oc_on_bastion_elf_check.rc not in [0, 1, 2]
 
 - name: Set fact — fetch Linux oc for mirror check when missing or wrong format (e.g. Darwin copy)
   ansible.builtin.set_fact:

--- a/roles/ignition/tasks/ensure_oc_on_bastion_for_mirror_check.yml
+++ b/roles/ignition/tasks/ensure_oc_on_bastion_for_mirror_check.yml
@@ -1,16 +1,29 @@
 ---
 # Ensure Linux oc exists under bastion_install_dir/bin for mirror digest preflight (client tarball only).
-- name: Check for Linux oc binary on bastion
-  ansible.builtin.stat:
-    path: "{{ bastion_install_dir }}/bin/oc"
-  register: ignition_oc_on_bastion_stat
+# Controller may be macOS: sync or prior runs can leave Mach-O binaries; existence alone is not enough.
+- name: Check whether bastion oc is missing or not Linux ELF
+  ansible.builtin.shell: |
+    set -euo pipefail
+    o="{{ bastion_install_dir }}/bin/oc"
+    if [ ! -f "$o" ]; then
+      exit 2
+    fi
+    h=$(head -c 4 "$o" | od -An -t x1 | tr -d '[:space:]')
+    case "$h" in 7f454c46*) exit 0;; *) exit 1;; esac
+  register: ignition_oc_on_bastion_elf_check
+  changed_when: false
+  failed_when: false
+
+- name: Set fact — fetch Linux oc for mirror check when missing or wrong format (e.g. Darwin copy)
+  ansible.builtin.set_fact:
+    ignition_oc_on_bastion_needs_fetch: "{{ ignition_oc_on_bastion_elf_check.rc | int != 0 }}"
 
 - name: Ensure temp directory for OCP client download on bastion
   ansible.builtin.file:
     path: "{{ ignition_mirror_check_bastion_tmp }}"
     state: directory
     mode: "0700"
-  when: not ignition_oc_on_bastion_stat.stat.exists | default(false)
+  when: ignition_oc_on_bastion_needs_fetch | bool
 
 - name: Download openshift-client to bastion for mirror check
   ansible.builtin.get_url:
@@ -18,21 +31,21 @@
     dest: "{{ ignition_mirror_check_bastion_tmp }}/openshift-client-linux.tar.gz"
     mode: "0644"
     validate_certs: "{{ ignition_ocp_mirror_validate_certs | default(true) | bool }}"
-  when: not ignition_oc_on_bastion_stat.stat.exists | default(false)
+  when: ignition_oc_on_bastion_needs_fetch | bool
 
 - name: Extract openshift-client on bastion
   ansible.builtin.unarchive:
     src: "{{ ignition_mirror_check_bastion_tmp }}/openshift-client-linux.tar.gz"
     dest: "{{ ignition_mirror_check_bastion_tmp }}"
     remote_src: true
-  when: not ignition_oc_on_bastion_stat.stat.exists | default(false)
+  when: ignition_oc_on_bastion_needs_fetch | bool
 
 - name: Ensure bastion bin directory exists
   ansible.builtin.file:
     path: "{{ bastion_install_dir }}/bin"
     state: directory
     mode: "0755"
-  when: not ignition_oc_on_bastion_stat.stat.exists | default(false)
+  when: ignition_oc_on_bastion_needs_fetch | bool
 
 - name: Install oc binary on bastion for mirror check
   ansible.builtin.shell: |
@@ -40,11 +53,11 @@
     BIN=$(find "{{ ignition_mirror_check_bastion_tmp }}" -name 'oc' -type f 2>/dev/null | head -1)
     cp "$BIN" "{{ bastion_install_dir }}/bin/oc"
     chmod 0755 "{{ bastion_install_dir }}/bin/oc"
-  when: not ignition_oc_on_bastion_stat.stat.exists | default(false)
+  when: ignition_oc_on_bastion_needs_fetch | bool
   changed_when: true
 
 - name: Remove mirror check temp directory on bastion
   ansible.builtin.file:
     path: "{{ ignition_mirror_check_bastion_tmp }}"
     state: absent
-  when: not ignition_oc_on_bastion_stat.stat.exists | default(false)
+  when: ignition_oc_on_bastion_needs_fetch | bool

--- a/roles/ignition/tasks/ensure_openshift_install.yml
+++ b/roles/ignition/tasks/ensure_openshift_install.yml
@@ -74,6 +74,32 @@
     - aws_nodes
     - ec2
 
+- name: Stat user-pinned oc-mirror binary
+  ansible.builtin.stat:
+    path: "{{ openshift_oc_mirror_binary_path }}"
+  register: ignition_oc_mirror_pin_stat
+  when: openshift_oc_mirror_binary_path | default('') | length > 0
+  tags:
+    - ignition
+    - config
+    - aws_nodes
+    - ec2
+
+- name: Require pinned oc-mirror path to exist
+  ansible.builtin.assert:
+    that:
+      - ignition_oc_mirror_pin_stat.stat.exists | default(false)
+      - ignition_oc_mirror_pin_stat.stat.isreg | default(false) or ignition_oc_mirror_pin_stat.stat.islnk | default(false)
+      - ignition_oc_mirror_pin_stat.stat.executable | default(false)
+    fail_msg: >-
+      openshift_oc_mirror_binary_path={{ openshift_oc_mirror_binary_path }} is missing or not executable.
+  when: openshift_oc_mirror_binary_path | default('') | length > 0
+  tags:
+    - ignition
+    - config
+    - aws_nodes
+    - ec2
+
 - name: Set mirror archive names for controller OS
   ansible.builtin.set_fact:
     ignition_ocp_installer_archive: "{{ _inst_arch }}"
@@ -315,6 +341,21 @@
     fail_msg: >-
       oc missing at {{ openshift_client_cmd }}.
       Check mirror URL (forge_ocp_mirror_base_url / forge_ocp_mirror_channel) and network access.
+  tags:
+    - ignition
+    - config
+    - aws_nodes
+    - ec2
+
+- name: Ensure controller oc-mirror matches OCP mirror channel (Linux)
+  ansible.builtin.include_tasks: ensure_oc_mirror_install.yml
+  vars:
+    ignition_oc_mirror_target_bin_dir: "{{ install_dir }}/bin"
+    ignition_oc_mirror_download_tmp: "{{ install_dir }}/.forge-download-cache/oc-mirror-extract"
+  when:
+    - forge_oc_mirror_install_enabled | default(true) | bool
+    - openshift_oc_mirror_binary_path | default('') | length == 0
+    - ansible_facts['system'] == 'Linux'
   tags:
     - ignition
     - config

--- a/roles/ignition/tasks/ensure_openshift_install.yml
+++ b/roles/ignition/tasks/ensure_openshift_install.yml
@@ -1,5 +1,6 @@
 ---
 # Install openshift-install + oc under install_dir/bin from forge_ocp_mirror_* (same channel as bastion).
+# Optionally installs or pins oc-mirror on Linux controllers (see ensure_oc_mirror_install.yml).
 # Sets host facts openshift_install_cmd and openshift_client_cmd for later plays (localhost).
 
 - name: Stat openshift-install under install_dir
@@ -146,12 +147,17 @@
   loop:
     - "{{ install_dir }}/bin"
     - "{{ install_dir }}/.forge-download-cache"
-  when:
-    - >-
-        (openshift_install_binary_path | default('') | length == 0
-        and not ignition_ocp_install_in_dir_stat.stat.exists | default(false))
-        or (openshift_client_binary_path | default('') | length == 0
-        and not ignition_ocp_oc_in_dir_stat.stat.exists | default(false))
+  when: >-
+    (
+      (openshift_install_binary_path | default('') | length == 0
+      and not ignition_ocp_install_in_dir_stat.stat.exists | default(false))
+      or (openshift_client_binary_path | default('') | length == 0
+      and not ignition_ocp_oc_in_dir_stat.stat.exists | default(false))
+      or (forge_oc_mirror_install_enabled | default(false) | bool
+          and openshift_oc_mirror_binary_path | default('') | length == 0
+          and ansible_facts['system'] == 'Linux')
+      or (openshift_oc_mirror_binary_path | default('') | length > 0)
+    )
   tags:
     - ignition
     - config
@@ -347,13 +353,40 @@
     - aws_nodes
     - ec2
 
+- name: Install pinned oc-mirror into install_dir/bin
+  ansible.builtin.copy:
+    src: "{{ openshift_oc_mirror_binary_path | expanduser }}"
+    dest: "{{ install_dir }}/bin/oc-mirror"
+    mode: "0755"
+  when:
+    - openshift_oc_mirror_binary_path | default('') | length > 0
+    - ansible_facts['system'] == 'Linux'
+  tags:
+    - ignition
+    - config
+    - aws_nodes
+    - ec2
+
+- name: Set openshift_oc_mirror_cmd when pinned or installed under install_dir/bin  # noqa: var-naming[no-role-prefix]
+  ansible.builtin.set_fact:
+    openshift_oc_mirror_cmd: "{{ install_dir }}/bin/oc-mirror"
+  when:
+    - >-
+      (openshift_oc_mirror_binary_path | default('') | length > 0)
+      or (forge_oc_mirror_install_enabled | default(false) | bool and ansible_facts['system'] == 'Linux')
+  tags:
+    - ignition
+    - config
+    - aws_nodes
+    - ec2
+
 - name: Ensure controller oc-mirror matches OCP mirror channel (Linux)
   ansible.builtin.include_tasks: ensure_oc_mirror_install.yml
   vars:
     ignition_oc_mirror_target_bin_dir: "{{ install_dir }}/bin"
     ignition_oc_mirror_download_tmp: "{{ install_dir }}/.forge-download-cache/oc-mirror-extract"
   when:
-    - forge_oc_mirror_install_enabled | default(true) | bool
+    - forge_oc_mirror_install_enabled | default(false) | bool
     - openshift_oc_mirror_binary_path | default('') | length == 0
     - ansible_facts['system'] == 'Linux'
   tags:

--- a/roles/ignition/templates/image-content-source-policy.yaml.j2
+++ b/roles/ignition/templates/image-content-source-policy.yaml.j2
@@ -8,7 +8,7 @@ spec:
         - "{{ ignition_mirror_registry_url_resolved }}/{{ mirror_registry_release_path | default('openshift/release') }}"
       source: quay.io/openshift-release-dev/ocp-release
     - mirrors:
-        - "{{ ignition_mirror_registry_url_resolved }}/{{ mirror_registry_release_path | default('openshift/release') }}"
+        - "{{ ignition_mirror_registry_url_resolved }}/{{ mirror_registry_art_dev_path | default(mirror_registry_release_path) | default('openshift/release') }}"
       source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 {% for item in mirror_registry_extra_image_content_sources | default([]) %}
     - mirrors:

--- a/roles/ignition/templates/image-digest-mirror-set.yaml.j2
+++ b/roles/ignition/templates/image-digest-mirror-set.yaml.j2
@@ -8,7 +8,7 @@ spec:
         - "{{ ignition_mirror_registry_url_resolved }}/{{ mirror_registry_release_path | default('openshift/release') }}"
       source: quay.io/openshift-release-dev/ocp-release
     - mirrors:
-        - "{{ ignition_mirror_registry_url_resolved }}/{{ mirror_registry_release_path | default('openshift/release') }}"
+        - "{{ ignition_mirror_registry_url_resolved }}/{{ mirror_registry_art_dev_path | default(mirror_registry_release_path) | default('openshift/release') }}"
       source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 {% for item in mirror_registry_extra_image_content_sources | default([]) %}
     - mirrors:

--- a/roles/ignition/templates/install-config.yaml.j2
+++ b/roles/ignition/templates/install-config.yaml.j2
@@ -37,7 +37,7 @@ imageDigestSources:
       - "{{ ignition_mirror_registry_url_resolved }}/{{ mirror_registry_release_path | default('openshift/release') }}"
     source: quay.io/openshift-release-dev/ocp-release
   - mirrors:
-      - "{{ ignition_mirror_registry_url_resolved }}/{{ mirror_registry_release_path | default('openshift/release') }}"
+      - "{{ ignition_mirror_registry_url_resolved }}/{{ mirror_registry_art_dev_path | default(mirror_registry_release_path) | default('openshift/release') }}"
     source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 {% for item in mirror_registry_extra_image_content_sources | default([]) %}
   - mirrors:
@@ -52,7 +52,7 @@ imageContentSources:
       - "{{ ignition_mirror_registry_url_resolved }}/{{ mirror_registry_release_path | default('openshift/release') }}"
     source: quay.io/openshift-release-dev/ocp-release
   - mirrors:
-      - "{{ ignition_mirror_registry_url_resolved }}/{{ mirror_registry_release_path | default('openshift/release') }}"
+      - "{{ ignition_mirror_registry_url_resolved }}/{{ mirror_registry_art_dev_path | default(mirror_registry_release_path) | default('openshift/release') }}"
     source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 {% for item in mirror_registry_extra_image_content_sources | default([]) %}
   - mirrors:

--- a/roles/rhoai/README.md
+++ b/roles/rhoai/README.md
@@ -1,0 +1,64 @@
+# RHOAI Role
+
+Day-2 install of **Red Hat OpenShift AI** on a Gryphon Forge cluster: cluster prep,
+default StorageClass / EBS CSI checks, optional mirrored CatalogSource/IDMS apply,
+operator subscriptions, `DSCInitialization`, `DataScienceCluster`, and verification.
+
+## Playbook
+
+```bash
+# 1) (Disconnected) Mirror operators + workbench images on the Nest bastion
+./scripts/mirror-rhoai.sh
+
+# 2) Install RHOAI (runs on bastion when foundry provides one)
+ansible-playbook playbooks/install_rhoai.yml -i inventory/hosts.yml \
+  -e @../gryphon-foundry/foundry_output.json \
+  -e foundry_output_path=../gryphon-foundry/foundry_output.json \
+  -e bastion_ssh_private_key_path=../gryphon-foundry/bastion-key.pem \
+  -e rhoai_apply_mirror_resources=true \
+  -e rhoai_mirror_resources_dir=/home/ec2-user/oc-mirror-workspace-rhoai/working-dir/cluster-resources
+```
+
+## Tags
+
+| Tag | Stage |
+|-----|--------|
+| `prep` | kubeconfig, API, nodes, workers, cluster operators |
+| `storage` | EBS CSI + default StorageClass + optional PVC smoke test |
+| `mirror_resources` | Apply oc-mirror IDMS/ITMS/CatalogSource YAMLs |
+| `operators` | cert-manager → optional mesh/GPU → rhods-operator |
+| `dsc` | DSCI then DSC |
+| `verify` | Dashboard route + report |
+| `rhoai` | All of the above |
+
+## Key variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `rhoai_channel` | `stable-3.4` | rhods-operator channel |
+| `rhoai_starting_csv` | `""` | Optional CSV pin |
+| `rhoai_install_cert_manager` | `true` | Required for RHOAI 3.x |
+| `rhoai_install_servicemesh` | `false` | OSSM3 (gateway / 2.x-style) |
+| `rhoai_install_gpu_stack` | `gpu_worker_count > 0` | NFD + NVIDIA GPU Operator |
+| `rhoai_ensure_default_storage_class` | `true` | Create/annotate default SC |
+| `rhoai_storage_class_name` | `gp3-csi` | Created when no default exists |
+| `rhoai_storage_smoke_test` | `true` | Bind a 1Gi PVC then delete |
+| `rhoai_apply_mirror_resources` | `false` | Apply `rhoai_mirror_resources_dir` |
+| `rhoai_mirror_ca_pem` | foundry trust bundle | DSCI `customCABundle` |
+
+See `defaults/main.yml` for DSC component toggles and timeouts.
+
+## Order of operations
+
+1. **prep** — cluster must be healthy with enough workers.
+2. **storage** — require `ebs.csi.aws.com` ClusterCSIDriver; ensure a default StorageClass (`gp3-csi` if needed); optional PVC smoke test.
+3. **mirror_resources** (optional) — apply oc-mirror outputs so PackageManifests exist.
+4. **operators** — cert-manager, optional Service Mesh / NFD / GPU, then `rhods-operator`.
+5. **dsc** — DSCI (wait Ready) then DSC (wait Ready).
+6. **verify** — dashboard route; write `rhoai-install-report.txt`.
+
+## References
+
+- [docs/RHOAI-disconnected-install.md](../../docs/RHOAI-disconnected-install.md)
+- [rh-aiservices-bu/disconnected-rhoai](https://github.com/rh-aiservices-bu/disconnected-rhoai)
+- [redhat-ai-services/ai-accelerator](https://github.com/redhat-ai-services/ai-accelerator)

--- a/roles/rhoai/defaults/main.yml
+++ b/roles/rhoai/defaults/main.yml
@@ -1,0 +1,84 @@
+---
+# RHOAI (OpenShift AI) day-2 install defaults
+# Overridden by playbooks/install_rhoai.yml when targeting bastion.
+
+rhoai_install_dir: "{{ install_dir }}"
+rhoai_oc_cmd: oc
+rhoai_controller_install_dir: "{{ install_dir }}"
+rhoai_kubeconfig: "{{ rhoai_install_dir }}/auth/kubeconfig"
+
+# Versions / channels (confirm against access.redhat.com/articles/rhoai-supported-configs)
+rhoai_channel: "stable-3.4"
+rhoai_starting_csv: ""  # optional pin, e.g. rhods-operator.v3.4.2
+rhoai_cert_manager_channel: "stable-v1"
+rhoai_nfd_channel: "stable"
+rhoai_gpu_operator_channel: "stable"
+rhoai_servicemesh_channel: "stable"
+rhoai_servicemesh_package: "servicemeshoperator3"
+
+# Feature toggles
+rhoai_install_cert_manager: true
+# RHOAI 3.x RawDeployment does not need Knative/OSSM; set true for gateway / 2.x-style serving
+rhoai_install_servicemesh: false
+rhoai_install_gpu_stack: "{{ (gpu_worker_count | default(0) | int) > 0 }}"
+rhoai_require_package_manifests: true
+
+# Prep gates
+rhoai_min_worker_nodes: 2
+rhoai_fail_on_not_ready_nodes: true
+rhoai_fail_on_degraded_operators: true
+
+# Storage
+rhoai_ensure_default_storage_class: true
+rhoai_storage_class_name: "gp3-csi"
+rhoai_storage_class_provisioner: "ebs.csi.aws.com"
+rhoai_storage_class_type: "gp3"
+rhoai_storage_class_encrypted: true
+rhoai_require_ebs_csi_driver: true
+rhoai_storage_smoke_test: true
+rhoai_storage_smoke_namespace: "gryphon-rhoai-storage-test"
+rhoai_storage_smoke_pvc_size: "1Gi"
+rhoai_storage_smoke_timeout_seconds: 300
+
+# Optional: apply oc-mirror cluster-resources (IDMS/ITMS/CatalogSource) before operators
+rhoai_apply_mirror_resources: false
+rhoai_mirror_resources_dir: ""  # e.g. ~/oc-mirror-workspace-rhoai/working-dir/cluster-resources
+
+# Mirror registry CA for DSCI trustedCABundle (PEM string or path)
+rhoai_mirror_ca_pem: "{{ mirror_registry_additional_trust_bundle | default('', true) }}"
+rhoai_mirror_ca_file: ""  # if set and readable on the target host, preferred over pem var
+
+# DSC / DSCI
+rhoai_dsci_name: "default-dsci"
+rhoai_dsc_name: "default-dsc"
+rhoai_applications_namespace: "redhat-ods-applications"
+rhoai_monitoring_namespace: "redhat-ods-monitoring"
+rhoai_operator_namespace: "redhat-ods-operator"
+rhoai_dsci_timeout_seconds: 1200
+rhoai_dsc_timeout_seconds: 1800
+rhoai_csv_timeout_seconds: 1200
+rhoai_csv_retry_delay: 30
+
+# DSC component managementState (RHOAI 3.x / datasciencecluster v2)
+rhoai_dsc_components:
+  dashboard: Managed
+  workbenches: Managed
+  kserve: Managed
+  aipipelines: Managed
+  modelregistry: Managed
+  trainer: Removed
+  trainingoperator: Removed
+  kueue: Removed
+  ray: Removed
+  sparkoperator: Removed
+  trustyai: Removed
+  mlflowoperator: Removed
+  feastoperator: Removed
+  llamastackoperator: Removed
+
+rhoai_model_registries_namespace: "rhoai-model-registries"
+rhoai_kserve_raw_deployment_service_config: "Headless"
+
+# Report
+rhoai_report_filename: "rhoai-install-report.txt"
+rhoai_sync_report_to_controller: true

--- a/roles/rhoai/tasks/apply_mirror_resources.yml
+++ b/roles/rhoai/tasks/apply_mirror_resources.yml
@@ -1,0 +1,80 @@
+---
+# Apply IDMS / ITMS / CatalogSource YAMLs produced by oc-mirror (scripts/mirror-rhoai.sh)
+
+- name: Require rhoai_mirror_resources_dir
+  ansible.builtin.assert:
+    that:
+      - rhoai_mirror_resources_dir | default('') | length > 0
+    fail_msg: >-
+      rhoai_apply_mirror_resources=true but rhoai_mirror_resources_dir is empty.
+      Point it at oc-mirror working-dir/cluster-resources
+      (see scripts/mirror-rhoai.sh).
+
+- name: Stat mirror resources directory
+  ansible.builtin.stat:
+    path: "{{ rhoai_mirror_resources_dir | expanduser }}"
+  register: rhoai_mirror_dir_stat
+
+- name: Fail if mirror resources directory missing
+  ansible.builtin.fail:
+    msg: "Mirror resources directory not found: {{ rhoai_mirror_resources_dir }}"
+  when: not rhoai_mirror_dir_stat.stat.exists or not rhoai_mirror_dir_stat.stat.isdir
+
+- name: Find YAML manifests in mirror resources directory
+  ansible.builtin.find:
+    paths: "{{ rhoai_mirror_resources_dir | expanduser }}"
+    patterns:
+      - "*.yaml"
+      - "*.yml"
+    recurse: true
+  register: rhoai_mirror_yaml_files
+
+- name: Fail if no mirror resource YAMLs found
+  ansible.builtin.fail:
+    msg: "No YAML files under {{ rhoai_mirror_resources_dir }}"
+  when: rhoai_mirror_yaml_files.files | length == 0
+
+# Default OperatorHub catalogs pull registry.redhat.io and block OLM resolution in air gaps.
+- name: Disable default OperatorHub catalog sources
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} patch OperatorHub cluster --type json
+      --kubeconfig={{ rhoai_kubeconfig }}
+      -p '[{"op":"add","path":"/spec/disableAllDefaultSources","value":true}]'
+  register: rhoai_operatorhub_patch
+  changed_when: "'patched' in rhoai_operatorhub_patch.stdout or 'configured' in rhoai_operatorhub_patch.stdout"
+
+- name: Remove default CatalogSources if still present
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} delete catalogsource
+      redhat-operators certified-operators community-operators redhat-marketplace
+      -n openshift-marketplace --kubeconfig={{ rhoai_kubeconfig }}
+      --ignore-not-found=true
+  register: rhoai_default_cs_delete
+  changed_when: "'deleted' in rhoai_default_cs_delete.stdout"
+
+- name: Apply mirrored cluster resources
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} apply --kubeconfig={{ rhoai_kubeconfig }}
+      -f {{ item.path }}
+  loop: "{{ rhoai_mirror_yaml_files.files }}"
+  loop_control:
+    label: "{{ item.path | basename }}"
+  register: rhoai_mirror_apply
+  changed_when: "'created' in rhoai_mirror_apply.stdout or 'configured' in rhoai_mirror_apply.stdout"
+
+- name: Wait for PackageManifest rhods-operator
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} get packagemanifest rhods-operator
+      -n openshift-marketplace
+      --kubeconfig={{ rhoai_kubeconfig }}
+      -o jsonpath='{.metadata.name}'
+  register: rhoai_pkg_rhods
+  until: rhoai_pkg_rhods.stdout == 'rhods-operator'
+  retries: 60
+  delay: 10
+  changed_when: false
+  when: rhoai_require_package_manifests | bool

--- a/roles/rhoai/tasks/dsc.yml
+++ b/roles/rhoai/tasks/dsc.yml
@@ -1,0 +1,142 @@
+---
+# Apply DSCInitialization (wait Ready), then DataScienceCluster
+
+- name: Resolve mirror CA PEM for DSCI
+  ansible.builtin.set_fact:
+    rhoai_dsci_ca_bundle: "{{ rhoai_mirror_ca_pem | default('', true) | trim }}"
+
+- name: Load mirror CA from file when provided
+  when:
+    - rhoai_mirror_ca_file | default('') | length > 0
+  block:
+    - name: Stat mirror CA file
+      ansible.builtin.stat:
+        path: "{{ rhoai_mirror_ca_file | expanduser }}"
+      register: rhoai_mirror_ca_stat
+
+    - name: Read mirror CA file
+      ansible.builtin.slurp:
+        src: "{{ rhoai_mirror_ca_file | expanduser }}"
+      register: rhoai_mirror_ca_slurp
+      when: rhoai_mirror_ca_stat.stat.exists | default(false)
+
+    - name: Set CA bundle from file
+      ansible.builtin.set_fact:
+        rhoai_dsci_ca_bundle: "{{ rhoai_mirror_ca_slurp.content | b64decode | trim }}"
+      when: rhoai_mirror_ca_slurp is defined and rhoai_mirror_ca_slurp.content is defined
+
+- name: Warn when DSCI customCABundle is empty (disconnected workbenches may fail TLS to mirror)
+  ansible.builtin.debug:
+    msg: >-
+      No mirror CA PEM configured (rhoai_mirror_ca_pem / rhoai_mirror_ca_file /
+      mirror_registry_additional_trust_bundle). DSCI trustedCABundle.customCABundle
+      will be empty.
+  when: rhoai_dsci_ca_bundle | default('') | length == 0
+
+- name: Wait for RHOAI conversion webhook Service
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} get svc rhods-operator-service
+      -n {{ rhoai_operator_namespace }}
+      --kubeconfig={{ rhoai_kubeconfig }}
+      -o jsonpath='{.metadata.name}'
+  register: rhoai_webhook_svc
+  until: rhoai_webhook_svc.stdout | length > 0
+  retries: 60
+  delay: 5
+  changed_when: false
+
+- name: Wait for RHOAI conversion webhook endpoints
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} get endpoints rhods-operator-service
+      -n {{ rhoai_operator_namespace }}
+      --kubeconfig={{ rhoai_kubeconfig }}
+      -o jsonpath='{.subsets[*].addresses[*].ip}'
+  register: rhoai_webhook_eps
+  until: rhoai_webhook_eps.stdout | length > 0
+  retries: 60
+  delay: 5
+  changed_when: false
+
+- name: Stage DSCI manifest
+  ansible.builtin.tempfile:
+    state: file
+    suffix: -dsci.yml
+  register: rhoai_dsci_tmp
+
+- name: Write DSCI manifest
+  ansible.builtin.copy:
+    dest: "{{ rhoai_dsci_tmp.path }}"
+    mode: "0644"
+    content: "{{ lookup('template', 'dsci.yml.j2') }}"
+
+- name: Apply DSCInitialization
+  ansible.builtin.command:
+    cmd: "{{ rhoai_oc_cmd }} apply --kubeconfig={{ rhoai_kubeconfig }} -f {{ rhoai_dsci_tmp.path }}"
+  register: rhoai_dsci_apply
+  changed_when: "'created' in rhoai_dsci_apply.stdout or 'configured' in rhoai_dsci_apply.stdout"
+
+- name: Wait for DSCInitialization Ready (phase or condition)
+  ansible.builtin.shell:
+    cmd: >-
+      set -o pipefail;
+      phase=$({{ rhoai_oc_cmd }} get dscinitialization {{ rhoai_dsci_name }}
+      --kubeconfig={{ rhoai_kubeconfig }} -o jsonpath='{.status.phase}' 2>/dev/null || true);
+      cond=$({{ rhoai_oc_cmd }} get dscinitialization {{ rhoai_dsci_name }}
+      --kubeconfig={{ rhoai_kubeconfig }}
+      -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || true);
+      if [ "$phase" = "Ready" ] || [ "$cond" = "True" ]; then echo Ready; else echo "$phase|$cond"; exit 1; fi
+  args:
+    executable: /bin/bash
+  register: rhoai_dsci_ready
+  until: rhoai_dsci_ready.stdout == 'Ready'
+  retries: "{{ ((rhoai_dsci_timeout_seconds | int) / 20) | int }}"
+  delay: 20
+  changed_when: false
+
+- name: Remove DSCI tempfile
+  ansible.builtin.file:
+    path: "{{ rhoai_dsci_tmp.path }}"
+    state: absent
+
+- name: Stage DSC manifest
+  ansible.builtin.tempfile:
+    state: file
+    suffix: -dsc.yml
+  register: rhoai_dsc_tmp
+
+- name: Write DSC manifest
+  ansible.builtin.copy:
+    dest: "{{ rhoai_dsc_tmp.path }}"
+    mode: "0644"
+    content: "{{ lookup('template', 'dsc.yml.j2') }}"
+
+- name: Apply DataScienceCluster
+  ansible.builtin.command:
+    cmd: "{{ rhoai_oc_cmd }} apply --kubeconfig={{ rhoai_kubeconfig }} -f {{ rhoai_dsc_tmp.path }}"
+  register: rhoai_dsc_apply
+  changed_when: "'created' in rhoai_dsc_apply.stdout or 'configured' in rhoai_dsc_apply.stdout"
+
+- name: Wait for DataScienceCluster Ready (phase or condition)
+  ansible.builtin.shell:
+    cmd: >-
+      set -o pipefail;
+      phase=$({{ rhoai_oc_cmd }} get datasciencecluster {{ rhoai_dsc_name }}
+      --kubeconfig={{ rhoai_kubeconfig }} -o jsonpath='{.status.phase}' 2>/dev/null || true);
+      cond=$({{ rhoai_oc_cmd }} get datasciencecluster {{ rhoai_dsc_name }}
+      --kubeconfig={{ rhoai_kubeconfig }}
+      -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || true);
+      if [ "$phase" = "Ready" ] || [ "$cond" = "True" ]; then echo Ready; else echo "$phase|$cond"; exit 1; fi
+  args:
+    executable: /bin/bash
+  register: rhoai_dsc_ready
+  until: rhoai_dsc_ready.stdout == 'Ready'
+  retries: "{{ ((rhoai_dsc_timeout_seconds | int) / 30) | int }}"
+  delay: 30
+  changed_when: false
+
+- name: Remove DSC tempfile
+  ansible.builtin.file:
+    path: "{{ rhoai_dsc_tmp.path }}"
+    state: absent

--- a/roles/rhoai/tasks/gpu_cluster_policy.yml
+++ b/roles/rhoai/tasks/gpu_cluster_policy.yml
@@ -1,0 +1,74 @@
+---
+# Apply ClusterPolicy from GPU operator CSV alm-examples when missing
+
+- name: Check for existing ClusterPolicy
+  ansible.builtin.command:
+    cmd: "{{ rhoai_oc_cmd }} get clusterpolicy gpu-cluster-policy --kubeconfig={{ rhoai_kubeconfig }}"
+  register: rhoai_gpu_cp_get
+  changed_when: false
+  failed_when: false
+
+- name: Derive and apply ClusterPolicy from CSV alm-examples
+  when: rhoai_gpu_cp_get.rc != 0
+  block:
+    - name: Extract ClusterPolicy JSON from CSV
+      ansible.builtin.shell:
+        cmd: >-
+          set -o pipefail;
+          {{ rhoai_oc_cmd }} get csv -n nvidia-gpu-operator -o json --kubeconfig={{ rhoai_kubeconfig }}
+          | python3 -c '
+          import json, sys
+          data = json.load(sys.stdin)
+          for item in data.get("items", []):
+              name = item.get("metadata", {}).get("name", "")
+              if "gpu-operator-certified" not in name:
+                  continue
+              examples = item.get("metadata", {}).get("annotations", {}).get("alm-examples", "[]")
+              try:
+                  parsed = json.loads(examples) if examples else []
+              except json.JSONDecodeError:
+                  continue
+              for ex in parsed:
+                  if ex.get("kind") == "ClusterPolicy":
+                      if "metadata" not in ex:
+                          ex["metadata"] = {}
+                      ex["metadata"]["name"] = "gpu-cluster-policy"
+                      json.dump(ex, sys.stdout)
+                      sys.exit(0)
+          # Fallback: empty spec ClusterPolicy (operator fills defaults)
+          json.dump({
+              "apiVersion": "nvidia.com/v1",
+              "kind": "ClusterPolicy",
+              "metadata": {"name": "gpu-cluster-policy"},
+              "spec": {}
+          }, sys.stdout)
+          sys.exit(0)
+          '
+      args:
+        executable: /bin/bash
+      register: rhoai_gpu_cp_json
+      changed_when: false
+      failed_when: rhoai_gpu_cp_json.rc != 0 or (rhoai_gpu_cp_json.stdout | default('') | length) == 0
+
+    - name: Stage ClusterPolicy tempfile
+      ansible.builtin.tempfile:
+        state: file
+        suffix: -gpu-cp.json
+      register: rhoai_gpu_cp_tmp
+
+    - name: Write ClusterPolicy JSON
+      ansible.builtin.copy:
+        dest: "{{ rhoai_gpu_cp_tmp.path }}"
+        mode: "0644"
+        content: "{{ rhoai_gpu_cp_json.stdout }}"
+
+    - name: Apply ClusterPolicy
+      ansible.builtin.command:
+        cmd: "{{ rhoai_oc_cmd }} apply --kubeconfig={{ rhoai_kubeconfig }} -f {{ rhoai_gpu_cp_tmp.path }}"
+      register: rhoai_gpu_cp_apply
+      changed_when: "'created' in rhoai_gpu_cp_apply.stdout or 'configured' in rhoai_gpu_cp_apply.stdout"
+
+    - name: Remove ClusterPolicy tempfile
+      ansible.builtin.file:
+        path: "{{ rhoai_gpu_cp_tmp.path }}"
+        state: absent

--- a/roles/rhoai/tasks/main.yml
+++ b/roles/rhoai/tasks/main.yml
@@ -1,0 +1,69 @@
+---
+# RHOAI day-2 install: prep → storage → optional mirror CRs → operators → DSCI/DSC → verify
+
+- name: Include RHOAI cluster preparation
+  ansible.builtin.include_tasks:
+    file: prep.yml
+    apply:
+      tags:
+        - rhoai
+        - prep
+  tags:
+    - rhoai
+    - prep
+
+- name: Include RHOAI storage preparation
+  ansible.builtin.include_tasks:
+    file: storage.yml
+    apply:
+      tags:
+        - rhoai
+        - storage
+  tags:
+    - rhoai
+    - storage
+
+- name: Include apply mirrored catalog / IDMS resources
+  ansible.builtin.include_tasks:
+    file: apply_mirror_resources.yml
+    apply:
+      tags:
+        - rhoai
+        - mirror_resources
+  when: rhoai_apply_mirror_resources | bool
+  tags:
+    - rhoai
+    - mirror_resources
+
+- name: Include RHOAI operator subscriptions
+  ansible.builtin.include_tasks:
+    file: operators.yml
+    apply:
+      tags:
+        - rhoai
+        - operators
+  tags:
+    - rhoai
+    - operators
+
+- name: Include DSCInitialization and DataScienceCluster
+  ansible.builtin.include_tasks:
+    file: dsc.yml
+    apply:
+      tags:
+        - rhoai
+        - dsc
+  tags:
+    - rhoai
+    - dsc
+
+- name: Include RHOAI verification
+  ansible.builtin.include_tasks:
+    file: verify.yml
+    apply:
+      tags:
+        - rhoai
+        - verify
+  tags:
+    - rhoai
+    - verify

--- a/roles/rhoai/tasks/nfd_instance.yml
+++ b/roles/rhoai/tasks/nfd_instance.yml
@@ -1,0 +1,75 @@
+---
+# Create NodeFeatureDiscovery instance after NFD CSV is Succeeded
+
+- name: Resolve NFD operand image from CSV relatedImages
+  ansible.builtin.shell:
+    cmd: >-
+      set -o pipefail;
+      {{ rhoai_oc_cmd }} get csv -n openshift-nfd -o json --kubeconfig={{ rhoai_kubeconfig }}
+      | python3 -c 'import json,sys; d=json.load(sys.stdin); imgs=[];
+      items=[i for i in d.get("items",[]) if str(i.get("metadata",{}).get("name","")).startswith("nfd")];
+      for item in items:
+        for r in (item.get("spec",{}).get("relatedImages") or []):
+          img=r.get("image") or "";
+          if img: imgs.append(img);
+      # Prefer the operand image, not the operator controller image
+      pick=next((i for i in imgs if "ose-node-feature-discovery" in i and "operator" not in i), "");
+      if not pick:
+        pick=next((i for i in imgs if "node-feature-discovery" in i and "operator" not in i), "");
+      if not pick:
+        pick=next((i for i in imgs if "nfd" in i.lower() and "operator" not in i), "");
+      print(pick)'
+  args:
+    executable: /bin/bash
+  register: rhoai_nfd_image
+  changed_when: false
+  failed_when: false
+
+- name: Skip NFD instance when operand image unresolved
+  ansible.builtin.debug:
+    msg: >-
+      Could not resolve NFD operand image from CSV; create NodeFeatureDiscovery manually.
+  when: rhoai_nfd_image.stdout | default('') | length == 0
+
+- name: Apply NodeFeatureDiscovery instance
+  when: rhoai_nfd_image.stdout | default('') | length > 0
+  block:
+    - name: Stage NFD instance manifest
+      ansible.builtin.tempfile:
+        state: file
+        suffix: -nfd.yml
+      register: rhoai_nfd_tmp
+
+    - name: Write NFD instance manifest
+      ansible.builtin.copy:
+        dest: "{{ rhoai_nfd_tmp.path }}"
+        mode: "0644"
+        content: |
+          apiVersion: nfd.openshift.io/v1
+          kind: NodeFeatureDiscovery
+          metadata:
+            name: nfd-instance
+            namespace: openshift-nfd
+          spec:
+            operand:
+              image: {{ rhoai_nfd_image.stdout }}
+              servicePort: 12000
+            workerConfig:
+              configData: |
+                core:
+                  sleepInterval: 60s
+                sources:
+                  pci:
+                    deviceClassWhitelist: ["0200", "03"]
+                    deviceLabelFields: ["vendor"]
+
+    - name: Apply NFD instance
+      ansible.builtin.command:
+        cmd: "{{ rhoai_oc_cmd }} apply --kubeconfig={{ rhoai_kubeconfig }} -f {{ rhoai_nfd_tmp.path }}"
+      register: rhoai_nfd_apply
+      changed_when: "'created' in rhoai_nfd_apply.stdout or 'configured' in rhoai_nfd_apply.stdout"
+
+    - name: Remove NFD tempfile
+      ansible.builtin.file:
+        path: "{{ rhoai_nfd_tmp.path }}"
+        state: absent

--- a/roles/rhoai/tasks/operators.yml
+++ b/roles/rhoai/tasks/operators.yml
@@ -1,0 +1,107 @@
+---
+# Install operators in dependency order (cert-manager → optional mesh/GPU → RHOAI)
+
+- name: Install cert-manager operator
+  ansible.builtin.include_tasks: subscribe_operator.yml
+  vars:
+    rhoai_sub_package: openshift-cert-manager-operator
+    rhoai_sub_namespace: cert-manager-operator
+    rhoai_sub_channel: "{{ rhoai_cert_manager_channel }}"
+    rhoai_sub_og_scope: own
+    rhoai_sub_starting_csv: ""
+  when: rhoai_install_cert_manager | bool
+
+- name: Wait for cert-manager Certificate CRD
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} get crd certificates.cert-manager.io
+      --kubeconfig={{ rhoai_kubeconfig }}
+      -o jsonpath='{.metadata.name}'
+  register: rhoai_cert_manager_crd
+  until: rhoai_cert_manager_crd.stdout == 'certificates.cert-manager.io'
+  retries: 60
+  delay: 10
+  changed_when: false
+  when: rhoai_install_cert_manager | bool
+
+- name: Install Service Mesh 3 operator
+  ansible.builtin.include_tasks: subscribe_operator.yml
+  vars:
+    rhoai_sub_package: "{{ rhoai_servicemesh_package }}"
+    rhoai_sub_namespace: openshift-operators
+    rhoai_sub_channel: "{{ rhoai_servicemesh_channel }}"
+    rhoai_sub_og_scope: all
+    rhoai_sub_starting_csv: ""
+  when: rhoai_install_servicemesh | bool
+
+- name: Install NFD operator
+  ansible.builtin.include_tasks: subscribe_operator.yml
+  vars:
+    rhoai_sub_package: nfd
+    rhoai_sub_namespace: openshift-nfd
+    rhoai_sub_channel: "{{ rhoai_nfd_channel }}"
+    rhoai_sub_og_scope: own
+    rhoai_sub_starting_csv: ""
+  when: rhoai_install_gpu_stack | bool
+
+- name: Include NFD instance creation
+  ansible.builtin.include_tasks: nfd_instance.yml
+  when: rhoai_install_gpu_stack | bool
+
+- name: Install NVIDIA GPU operator
+  ansible.builtin.include_tasks: subscribe_operator.yml
+  vars:
+    rhoai_sub_package: gpu-operator-certified
+    rhoai_sub_namespace: nvidia-gpu-operator
+    rhoai_sub_channel: "{{ rhoai_gpu_operator_channel }}"
+    rhoai_sub_og_scope: own
+    rhoai_sub_starting_csv: ""
+  when: rhoai_install_gpu_stack | bool
+
+- name: Include GPU ClusterPolicy creation
+  ansible.builtin.include_tasks: gpu_cluster_policy.yml
+  when: rhoai_install_gpu_stack | bool
+
+- name: Install RHOAI (rhods-operator)
+  ansible.builtin.include_tasks: subscribe_operator.yml
+  vars:
+    rhoai_sub_package: rhods-operator
+    rhoai_sub_namespace: "{{ rhoai_operator_namespace }}"
+    rhoai_sub_channel: "{{ rhoai_channel }}"
+    rhoai_sub_og_scope: all
+    rhoai_sub_starting_csv: "{{ rhoai_starting_csv }}"
+
+- name: Wait for DataScienceCluster CRD
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} get crd datascienceclusters.datasciencecluster.opendatahub.io
+      --kubeconfig={{ rhoai_kubeconfig }}
+      -o jsonpath='{.metadata.name}'
+  register: rhoai_dsc_crd
+  until: rhoai_dsc_crd.stdout | default('') | length > 0
+  retries: 60
+  delay: 10
+  changed_when: false
+  failed_when: false
+
+- name: Wait for DSCInitialization CRD
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} get crd dscinitializations.dscinitialization.opendatahub.io
+      --kubeconfig={{ rhoai_kubeconfig }}
+      -o jsonpath='{.metadata.name}'
+  register: rhoai_dsci_crd
+  until: rhoai_dsci_crd.stdout | default('') | length > 0
+  retries: 60
+  delay: 10
+  changed_when: false
+  failed_when: false
+
+- name: Fail if RHOAI CRDs are missing
+  ansible.builtin.fail:
+    msg: >-
+      RHOAI CRDs not registered after rhods-operator install
+      (dsc={{ rhoai_dsc_crd.stdout | default('') }}, dsci={{ rhoai_dsci_crd.stdout | default('') }}).
+  when: >-
+    (rhoai_dsc_crd.stdout | default('') | length == 0)
+    or (rhoai_dsci_crd.stdout | default('') | length == 0)

--- a/roles/rhoai/tasks/prep.yml
+++ b/roles/rhoai/tasks/prep.yml
@@ -1,0 +1,92 @@
+---
+# Cluster readiness gates before RHOAI install
+
+- name: Verify kubeconfig exists
+  ansible.builtin.stat:
+    path: "{{ rhoai_install_dir }}/auth/kubeconfig"
+  register: rhoai_kubeconfig_stat
+
+- name: Fail if kubeconfig missing
+  ansible.builtin.fail:
+    msg: >-
+      Kubeconfig not found at {{ rhoai_install_dir }}/auth/kubeconfig.
+      Finish deploy_cluster (validation) first, or set rhoai_install_dir.
+  when: not rhoai_kubeconfig_stat.stat.exists
+
+- name: Set KUBECONFIG fact for subsequent tasks
+  ansible.builtin.set_fact:
+    rhoai_kubeconfig: "{{ rhoai_install_dir }}/auth/kubeconfig"
+
+- name: Check cluster API reachability
+  ansible.builtin.command:
+    cmd: "{{ rhoai_oc_cmd }} whoami --kubeconfig={{ rhoai_kubeconfig }}"
+  register: rhoai_oc_whoami
+  changed_when: false
+
+- name: Get cluster version
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} get clusterversion version
+      --kubeconfig={{ rhoai_kubeconfig }}
+      -o jsonpath='{.status.desired.version}'
+  register: rhoai_cluster_version
+  changed_when: false
+  failed_when: false
+
+- name: List nodes not Ready
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} get nodes --kubeconfig={{ rhoai_kubeconfig }}
+      -o jsonpath='{.items[?(@.status.conditions[?(@.type=="Ready")].status!="True")].metadata.name}'
+  register: rhoai_not_ready_nodes
+  changed_when: false
+  failed_when: false
+
+- name: Fail when nodes are not Ready
+  ansible.builtin.fail:
+    msg: "Nodes not Ready: {{ rhoai_not_ready_nodes.stdout }}"
+  when:
+    - rhoai_fail_on_not_ready_nodes | bool
+    - rhoai_not_ready_nodes.stdout | default('') | length > 0
+
+- name: Count worker nodes (role=worker)
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} get nodes -l node-role.kubernetes.io/worker
+      --kubeconfig={{ rhoai_kubeconfig }}
+      -o jsonpath='{.items[*].metadata.name}'
+  register: rhoai_worker_nodes
+  changed_when: false
+
+- name: Assert minimum worker node count
+  ansible.builtin.assert:
+    that:
+      - (rhoai_worker_nodes.stdout.split() | length) >= (rhoai_min_worker_nodes | int)
+    fail_msg: >-
+      RHOAI needs at least {{ rhoai_min_worker_nodes }} worker node(s);
+      found {{ rhoai_worker_nodes.stdout.split() | length }}
+      ({{ rhoai_worker_nodes.stdout | default('(none)') }}).
+
+- name: List cluster operators not Available
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} get co --kubeconfig={{ rhoai_kubeconfig }}
+      -o jsonpath='{.items[?(@.status.conditions[?(@.type=="Available")].status!="True")].metadata.name}'
+  register: rhoai_degraded_operators
+  changed_when: false
+  failed_when: false
+
+- name: Fail when cluster operators are not Available
+  ansible.builtin.fail:
+    msg: "Cluster operators not Available: {{ rhoai_degraded_operators.stdout }}"
+  when:
+    - rhoai_fail_on_degraded_operators | bool
+    - rhoai_degraded_operators.stdout | default('') | length > 0
+
+- name: Display prep summary
+  ansible.builtin.debug:
+    msg:
+      - "API identity: {{ rhoai_oc_whoami.stdout }}"
+      - "Cluster version: {{ rhoai_cluster_version.stdout | default('unknown') }}"
+      - "Workers: {{ rhoai_worker_nodes.stdout.split() | length }}"
+      - "RHOAI channel: {{ rhoai_channel }}"

--- a/roles/rhoai/tasks/storage.yml
+++ b/roles/rhoai/tasks/storage.yml
@@ -1,0 +1,229 @@
+---
+# Ensure a usable default StorageClass (AWS EBS CSI) for RHOAI PVCs
+
+- name: List StorageClasses
+  ansible.builtin.command:
+    cmd: "{{ rhoai_oc_cmd }} get sc --kubeconfig={{ rhoai_kubeconfig }} -o json"
+  register: rhoai_sc_json
+  changed_when: false
+
+- name: Parse StorageClass inventory
+  ansible.builtin.set_fact:
+    rhoai_storage_classes: "{{ (rhoai_sc_json.stdout | from_json)['items'] | default([]) }}"
+
+- name: Resolve default StorageClass name via jsonpath
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} get sc --kubeconfig={{ rhoai_kubeconfig }}
+      -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}'
+  register: rhoai_default_sc_name
+  changed_when: false
+  failed_when: false
+
+- name: Check AWS EBS CSI ClusterCSIDriver
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} get clustercsidriver ebs.csi.aws.com
+      --kubeconfig={{ rhoai_kubeconfig }}
+      -o jsonpath='{.metadata.name}'
+  register: rhoai_ebs_csi_driver
+  changed_when: false
+  failed_when: false
+
+- name: Fail when EBS CSI driver is required but missing
+  ansible.builtin.fail:
+    msg: >-
+      ClusterCSIDriver ebs.csi.aws.com was not found. OpenShift on AWS normally
+      installs this via the Cluster Storage Operator. Investigate
+      `oc get co storage` / `oc get pods -n openshift-cluster-csi-drivers`
+      before installing RHOAI (workbenches need PersistentVolumeClaims).
+  when:
+    - rhoai_require_ebs_csi_driver | bool
+    - rhoai_ebs_csi_driver.stdout | default('') | length == 0
+
+- name: Check EBS CSI controller pods
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} get pods -n openshift-cluster-csi-drivers
+      -l app=aws-ebs-csi-driver-controller
+      --kubeconfig={{ rhoai_kubeconfig }}
+      -o jsonpath='{.items[*].status.phase}'
+  register: rhoai_ebs_csi_pods
+  changed_when: false
+  failed_when: false
+  when: rhoai_ebs_csi_driver.stdout | default('') | length > 0
+
+- name: Fail when EBS CSI controller pods are not Running
+  ansible.builtin.fail:
+    msg: >-
+      aws-ebs-csi-driver-controller pods are not Running
+      (phases: {{ rhoai_ebs_csi_pods.stdout | default('none') }}).
+      Fix CSI before RHOAI PVC workloads.
+  when:
+    - rhoai_require_ebs_csi_driver | bool
+    - rhoai_ebs_csi_driver.stdout | default('') | length > 0
+    - rhoai_ebs_csi_pods is defined
+    - rhoai_ebs_csi_pods.stdout is defined
+    - (rhoai_ebs_csi_pods.stdout.split() | length) == 0
+      or ('Pending' in rhoai_ebs_csi_pods.stdout)
+      or ('Failed' in rhoai_ebs_csi_pods.stdout)
+      or ('CrashLoopBackOff' in rhoai_ebs_csi_pods.stdout)
+
+- name: Ensure a default StorageClass exists
+  when:
+    - rhoai_ensure_default_storage_class | bool
+    - rhoai_default_sc_name.stdout | default('') | trim | length == 0
+  block:
+    - name: Look for known EBS CSI StorageClass names
+      ansible.builtin.set_fact:
+        rhoai_candidate_sc: >-
+          {{
+            (rhoai_storage_classes | map(attribute='metadata.name') | list)
+            | select('match', '^(gp3-csi|gp2-csi|gp3|gp2)$')
+            | list
+            | first
+            | default('')
+          }}
+
+    - name: Annotate existing StorageClass as default
+      ansible.builtin.command:
+        cmd: >-
+          {{ rhoai_oc_cmd }} annotate sc {{ rhoai_candidate_sc }}
+          storageclass.kubernetes.io/is-default-class=true
+          --overwrite --kubeconfig={{ rhoai_kubeconfig }}
+      when: rhoai_candidate_sc | length > 0
+      register: rhoai_sc_annotate
+      changed_when: rhoai_sc_annotate.rc == 0
+
+    - name: Refresh default StorageClass name after annotate
+      ansible.builtin.command:
+        cmd: >-
+          {{ rhoai_oc_cmd }} get sc --kubeconfig={{ rhoai_kubeconfig }}
+          -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}'
+      register: rhoai_default_sc_name
+      changed_when: false
+      failed_when: false
+      when: rhoai_candidate_sc | length > 0
+
+    - name: Create gp3 StorageClass when still no default
+      when: rhoai_default_sc_name.stdout | default('') | trim | length == 0
+      block:
+        - name: Stage StorageClass tempfile
+          ansible.builtin.tempfile:
+            state: file
+            suffix: -gp3-sc.yml
+          register: rhoai_sc_tmp
+
+        - name: Write StorageClass manifest
+          ansible.builtin.copy:
+            dest: "{{ rhoai_sc_tmp.path }}"
+            mode: "0644"
+            content: "{{ lookup('template', 'storageclass-gp3.yml.j2') }}"
+
+        - name: Apply StorageClass
+          ansible.builtin.command:
+            cmd: "{{ rhoai_oc_cmd }} apply --kubeconfig={{ rhoai_kubeconfig }} -f {{ rhoai_sc_tmp.path }}"
+          register: rhoai_sc_apply
+          changed_when: "'created' in rhoai_sc_apply.stdout or 'configured' in rhoai_sc_apply.stdout"
+
+        - name: Remove StorageClass tempfile
+          ansible.builtin.file:
+            path: "{{ rhoai_sc_tmp.path }}"
+            state: absent
+
+        - name: Record created default StorageClass
+          ansible.builtin.set_fact:
+            rhoai_default_sc_name:
+              stdout: "{{ rhoai_storage_class_name }}"
+              stderr: ""
+              rc: 0
+
+- name: Fail when no default StorageClass is available
+  ansible.builtin.fail:
+    msg: >-
+      No default StorageClass found and none could be created.
+      RHOAI workbenches and pipelines require dynamic provisioning
+      (typically ebs.csi.aws.com). Create a StorageClass or set
+      rhoai_ensure_default_storage_class / rhoai_storage_class_*.
+  when: rhoai_default_sc_name.stdout | default('') | trim | length == 0
+
+- name: Set effective StorageClass for smoke test
+  ansible.builtin.set_fact:
+    rhoai_effective_storage_class: "{{ rhoai_default_sc_name.stdout.split() | first }}"
+
+- name: Run StorageClass PVC smoke test
+  when: rhoai_storage_smoke_test | bool
+  vars:
+    rhoai_storage_smoke_storage_class: "{{ rhoai_effective_storage_class }}"
+    rhoai_sub_namespace: "{{ rhoai_storage_smoke_namespace }}"
+  block:
+    - name: Stage smoke-test manifests directory
+      ansible.builtin.tempfile:
+        state: directory
+        suffix: -rhoai-smoke
+      register: rhoai_smoke_dir
+
+    - name: Write smoke-test namespace manifest
+      ansible.builtin.copy:
+        dest: "{{ rhoai_smoke_dir.path }}/namespace.yml"
+        mode: "0644"
+        content: "{{ lookup('template', 'namespace.yml.j2') }}"
+
+    - name: Write smoke PVC manifest
+      ansible.builtin.copy:
+        dest: "{{ rhoai_smoke_dir.path }}/pvc.yml"
+        mode: "0644"
+        content: "{{ lookup('template', 'storage-smoke-pvc.yml.j2') }}"
+
+    - name: Apply smoke-test namespace and PVC
+      ansible.builtin.command:
+        cmd: "{{ rhoai_oc_cmd }} apply --kubeconfig={{ rhoai_kubeconfig }} -f {{ rhoai_smoke_dir.path }}"
+      register: rhoai_smoke_apply
+      changed_when: "'created' in rhoai_smoke_apply.stdout or 'configured' in rhoai_smoke_apply.stdout"
+
+    # WaitForFirstConsumer classes stay Pending until a pod mounts the claim — that is healthy.
+    # Do not schedule a consumer pod here: disconnected clusters often cannot pull public pause images yet.
+    - name: Wait for smoke PVC Bound or WaitForFirstConsumer
+      ansible.builtin.shell:
+        cmd: >-
+          set -o pipefail;
+          phase=$({{ rhoai_oc_cmd }} get pvc gryphon-rhoai-smoke
+          -n {{ rhoai_storage_smoke_namespace }}
+          --kubeconfig={{ rhoai_kubeconfig }} -o jsonpath='{.status.phase}');
+          if [ "$phase" = "Bound" ]; then echo Bound; exit 0; fi;
+          reason=$({{ rhoai_oc_cmd }} get events -n {{ rhoai_storage_smoke_namespace }}
+          --kubeconfig={{ rhoai_kubeconfig }}
+          --field-selector involvedObject.name=gryphon-rhoai-smoke
+          -o jsonpath='{.items[-1:].reason}' 2>/dev/null || true);
+          if [ "$phase" = "Pending" ] && [ "$reason" = "WaitForFirstConsumer" ]; then
+            echo WaitForFirstConsumer; exit 0;
+          fi;
+          echo "$phase:$reason"; exit 1
+      args:
+        executable: /bin/bash
+      register: rhoai_smoke_pvc_phase
+      until: rhoai_smoke_pvc_phase.rc == 0
+      retries: "{{ ((rhoai_storage_smoke_timeout_seconds | int) / 10) | int }}"
+      delay: 10
+      changed_when: false
+
+    - name: Delete smoke-test namespace
+      ansible.builtin.command:
+        cmd: >-
+          {{ rhoai_oc_cmd }} delete namespace {{ rhoai_storage_smoke_namespace }}
+          --kubeconfig={{ rhoai_kubeconfig }}
+          --ignore-not-found=true --wait=false
+      register: rhoai_smoke_cleanup
+      changed_when: "'deleted' in rhoai_smoke_cleanup.stdout"
+
+    - name: Remove smoke-test staging directory
+      ansible.builtin.file:
+        path: "{{ rhoai_smoke_dir.path }}"
+        state: absent
+
+- name: Display storage summary
+  ansible.builtin.debug:
+    msg:
+      - "Default StorageClass: {{ rhoai_effective_storage_class }}"
+      - "EBS CSI driver: {{ rhoai_ebs_csi_driver.stdout | default('missing') }}"
+      - "PVC smoke test: {{ 'passed' if rhoai_storage_smoke_test | bool else 'skipped' }}"

--- a/roles/rhoai/tasks/subscribe_operator.yml
+++ b/roles/rhoai/tasks/subscribe_operator.yml
@@ -1,0 +1,99 @@
+---
+# Subscribe to a single OLM package (expects rhoai_sub_* vars)
+
+- name: Resolve CatalogSource for {{ rhoai_sub_package }}
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} get packagemanifest {{ rhoai_sub_package }}
+      -n openshift-marketplace
+      --kubeconfig={{ rhoai_kubeconfig }}
+      -o jsonpath='{.status.catalogSource}'
+  register: rhoai_sub_catalog_lookup
+  changed_when: false
+  failed_when: false
+
+- name: Fail when package is not in any CatalogSource
+  ansible.builtin.fail:
+    msg: >-
+      PackageManifest '{{ rhoai_sub_package }}' not found in openshift-marketplace.
+      Mirror the operator (scripts/mirror-rhoai.sh) and apply cluster-resources
+      (rhoai_apply_mirror_resources=true), or ensure the connected catalog is available.
+  when:
+    - rhoai_require_package_manifests | bool
+    - rhoai_sub_catalog_lookup.stdout | default('') | length == 0
+
+- name: Set catalog for subscription
+  ansible.builtin.set_fact:
+    rhoai_sub_catalog: "{{ rhoai_sub_catalog_lookup.stdout }}"
+
+- name: Stage subscription manifests for {{ rhoai_sub_package }}
+  ansible.builtin.tempfile:
+    state: directory
+    suffix: "-sub-{{ rhoai_sub_package }}"
+  register: rhoai_sub_dir
+
+- name: Write namespace for {{ rhoai_sub_package }}
+  ansible.builtin.copy:
+    dest: "{{ rhoai_sub_dir.path }}/00-namespace.yml"
+    mode: "0644"
+    content: "{{ lookup('template', 'namespace.yml.j2') }}"
+
+- name: Check for existing OperatorGroup in {{ rhoai_sub_namespace }}
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} get operatorgroup -n {{ rhoai_sub_namespace }}
+      --kubeconfig={{ rhoai_kubeconfig }}
+      -o jsonpath='{.items[*].metadata.name}'
+  register: rhoai_existing_ogs
+  changed_when: false
+  failed_when: false
+
+- name: Write OperatorGroup for {{ rhoai_sub_package }}
+  ansible.builtin.copy:
+    dest: "{{ rhoai_sub_dir.path }}/10-operatorgroup.yml"
+    mode: "0644"
+    content: "{{ lookup('template', 'operatorgroup.yml.j2') }}"
+  when: rhoai_existing_ogs.stdout | default('') | trim | length == 0
+
+- name: Write Subscription for {{ rhoai_sub_package }}
+  ansible.builtin.copy:
+    dest: "{{ rhoai_sub_dir.path }}/20-subscription.yml"
+    mode: "0644"
+    content: "{{ lookup('template', 'subscription.yml.j2') }}"
+
+- name: Apply Subscription resources for {{ rhoai_sub_package }}
+  ansible.builtin.command:
+    cmd: "{{ rhoai_oc_cmd }} apply --kubeconfig={{ rhoai_kubeconfig }} -f {{ rhoai_sub_dir.path }}"
+  register: rhoai_sub_apply
+  changed_when: "'created' in rhoai_sub_apply.stdout or 'configured' in rhoai_sub_apply.stdout"
+
+- name: Wait for installed CSV on Subscription {{ rhoai_sub_package }}
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} get subscription {{ rhoai_sub_package }}
+      -n {{ rhoai_sub_namespace }}
+      --kubeconfig={{ rhoai_kubeconfig }}
+      -o jsonpath='{.status.installedCSV}'
+  register: rhoai_sub_installed_csv
+  until: rhoai_sub_installed_csv.stdout | length > 0
+  retries: "{{ ((rhoai_csv_timeout_seconds | int) / (rhoai_csv_retry_delay | int)) | int }}"
+  delay: "{{ rhoai_csv_retry_delay | int }}"
+  changed_when: false
+
+- name: Wait for CSV Succeeded
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} get csv {{ rhoai_sub_installed_csv.stdout }}
+      -n {{ rhoai_sub_namespace }}
+      --kubeconfig={{ rhoai_kubeconfig }}
+      -o jsonpath='{.status.phase}'
+  register: rhoai_sub_csv_phase
+  until: rhoai_sub_csv_phase.stdout == 'Succeeded'
+  retries: "{{ ((rhoai_csv_timeout_seconds | int) / (rhoai_csv_retry_delay | int)) | int }}"
+  delay: "{{ rhoai_csv_retry_delay | int }}"
+  changed_when: false
+
+- name: Remove subscription staging directory
+  ansible.builtin.file:
+    path: "{{ rhoai_sub_dir.path }}"
+    state: absent

--- a/roles/rhoai/tasks/verify.yml
+++ b/roles/rhoai/tasks/verify.yml
@@ -1,0 +1,102 @@
+---
+# Post-install checks and report
+
+- name: Get DSCI status
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} get dscinitialization {{ rhoai_dsci_name }}
+      --kubeconfig={{ rhoai_kubeconfig }}
+      -o custom-columns=NAME:.metadata.name,PHASE:.status.phase --no-headers
+  register: rhoai_verify_dsci
+  changed_when: false
+  failed_when: false
+
+- name: Get DSC status
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} get datasciencecluster {{ rhoai_dsc_name }}
+      --kubeconfig={{ rhoai_kubeconfig }}
+      -o custom-columns=NAME:.metadata.name,PHASE:.status.phase --no-headers
+  register: rhoai_verify_dsc
+  changed_when: false
+  failed_when: false
+
+- name: Get RHOAI dashboard route
+  ansible.builtin.command:
+    cmd: >-
+      {{ rhoai_oc_cmd }} get route rhods-dashboard
+      -n {{ rhoai_applications_namespace }}
+      --kubeconfig={{ rhoai_kubeconfig }}
+      -o jsonpath='{.spec.host}'
+  register: rhoai_dashboard_host
+  changed_when: false
+  failed_when: false
+
+- name: List non-running pods in applications namespace
+  ansible.builtin.shell:
+    cmd: >-
+      set -o pipefail;
+      {{ rhoai_oc_cmd }} get pods -n {{ rhoai_applications_namespace }}
+      --kubeconfig={{ rhoai_kubeconfig }} --no-headers 2>/dev/null
+      | awk '$3!="Running" && $3!="Completed" {print}' || true
+  args:
+    executable: /bin/bash
+  register: rhoai_bad_pods
+  changed_when: false
+  failed_when: false
+
+- name: Write RHOAI install report
+  ansible.builtin.copy:
+    dest: "{{ rhoai_install_dir }}/{{ rhoai_report_filename }}"
+    mode: "0644"
+    content: |
+      Gryphon Forge RHOAI install report
+      Generated: {{ ansible_facts['date_time']['iso8601'] | default('unknown') }}
+      Ansible host: {{ inventory_hostname }}
+      Cluster version: {{ rhoai_cluster_version.stdout | default('unknown') }}
+      Default StorageClass: {{ rhoai_effective_storage_class | default('unknown') }}
+      RHOAI channel: {{ rhoai_channel }}
+
+      --- DSCInitialization ---
+      {{ rhoai_verify_dsci.stdout | default('') }}
+
+      --- DataScienceCluster ---
+      {{ rhoai_verify_dsc.stdout | default('') }}
+
+      --- Dashboard ---
+      {% if rhoai_dashboard_host.stdout | default('') | length > 0 %}
+      https://{{ rhoai_dashboard_host.stdout }}
+      {% else %}
+      (route not found yet)
+      {% endif %}
+
+      --- Non-running pods in {{ rhoai_applications_namespace }} ---
+      {{ rhoai_bad_pods.stdout | default('(none)') }}
+
+- name: Fetch RHOAI report to controller
+  ansible.builtin.fetch:
+    src: "{{ rhoai_install_dir }}/{{ rhoai_report_filename }}"
+    dest: "{{ rhoai_controller_install_dir }}/{{ rhoai_report_filename }}"
+    flat: true
+  when:
+    - inventory_hostname == 'bastion'
+    - rhoai_sync_report_to_controller | bool
+
+- name: Display RHOAI summary
+  ansible.builtin.debug:
+    msg:
+      - "DSCI: {{ rhoai_verify_dsci.stdout | default('unknown') }}"
+      - "DSC: {{ rhoai_verify_dsc.stdout | default('unknown') }}"
+      - >-
+        Dashboard:
+        {{ ('https://' ~ rhoai_dashboard_host.stdout)
+           if (rhoai_dashboard_host.stdout | default('') | length > 0)
+           else '(pending)' }}
+      - "Report: {{ rhoai_install_dir }}/{{ rhoai_report_filename }}"
+
+- name: Fail when dashboard route is missing
+  ansible.builtin.fail:
+    msg: >-
+      rhods-dashboard route not found in {{ rhoai_applications_namespace }}.
+      See {{ rhoai_install_dir }}/{{ rhoai_report_filename }}.
+  when: rhoai_dashboard_host.stdout | default('') | length == 0

--- a/roles/rhoai/templates/dsc.yml.j2
+++ b/roles/rhoai/templates/dsc.yml.j2
@@ -1,0 +1,40 @@
+apiVersion: datasciencecluster.opendatahub.io/v2
+kind: DataScienceCluster
+metadata:
+  name: {{ rhoai_dsc_name }}
+spec:
+  components:
+    dashboard:
+      managementState: {{ rhoai_dsc_components.dashboard }}
+    workbenches:
+      managementState: {{ rhoai_dsc_components.workbenches }}
+    kserve:
+      managementState: {{ rhoai_dsc_components.kserve }}
+{% if rhoai_dsc_components.kserve == 'Managed' %}
+      rawDeploymentServiceConfig: {{ rhoai_kserve_raw_deployment_service_config }}
+{% endif %}
+    aipipelines:
+      managementState: {{ rhoai_dsc_components.aipipelines }}
+    modelregistry:
+      managementState: {{ rhoai_dsc_components.modelregistry }}
+{% if rhoai_dsc_components.modelregistry == 'Managed' %}
+      registriesNamespace: {{ rhoai_model_registries_namespace }}
+{% endif %}
+    trainer:
+      managementState: {{ rhoai_dsc_components.trainer }}
+    trainingoperator:
+      managementState: {{ rhoai_dsc_components.trainingoperator }}
+    kueue:
+      managementState: {{ rhoai_dsc_components.kueue }}
+    ray:
+      managementState: {{ rhoai_dsc_components.ray }}
+    sparkoperator:
+      managementState: {{ rhoai_dsc_components.sparkoperator }}
+    trustyai:
+      managementState: {{ rhoai_dsc_components.trustyai }}
+    mlflowoperator:
+      managementState: {{ rhoai_dsc_components.mlflowoperator }}
+    feastoperator:
+      managementState: {{ rhoai_dsc_components.feastoperator }}
+    llamastackoperator:
+      managementState: {{ rhoai_dsc_components.llamastackoperator }}

--- a/roles/rhoai/templates/dsci.yml.j2
+++ b/roles/rhoai/templates/dsci.yml.j2
@@ -1,0 +1,17 @@
+apiVersion: dscinitialization.opendatahub.io/v1
+kind: DSCInitialization
+metadata:
+  name: {{ rhoai_dsci_name }}
+spec:
+  applicationsNamespace: {{ rhoai_applications_namespace }}
+  monitoring:
+    managementState: Managed
+    namespace: {{ rhoai_monitoring_namespace }}
+  trustedCABundle:
+    managementState: Managed
+{% if rhoai_dsci_ca_bundle | default('') | length > 0 %}
+    customCABundle: |
+{{ rhoai_dsci_ca_bundle | indent(6, true) }}
+{% else %}
+    customCABundle: ""
+{% endif %}

--- a/roles/rhoai/templates/namespace.yml.j2
+++ b/roles/rhoai/templates/namespace.yml.j2
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ rhoai_sub_namespace }}
+  labels:
+    gryphon.forge/rhoai: "true"

--- a/roles/rhoai/templates/operatorgroup.yml.j2
+++ b/roles/rhoai/templates/operatorgroup.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: {{ rhoai_sub_namespace }}-og
+  namespace: {{ rhoai_sub_namespace }}
+{% if rhoai_sub_og_scope | default('own') == 'all' %}
+spec: {}
+{% else %}
+spec:
+  targetNamespaces:
+    - {{ rhoai_sub_namespace }}
+{% endif %}

--- a/roles/rhoai/templates/storage-smoke-pvc.yml.j2
+++ b/roles/rhoai/templates/storage-smoke-pvc.yml.j2
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gryphon-rhoai-smoke
+  namespace: {{ rhoai_storage_smoke_namespace }}
+  labels:
+    gryphon.forge/rhoai-smoke: "true"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ rhoai_storage_smoke_pvc_size }}
+  storageClassName: {{ rhoai_storage_smoke_storage_class }}
+  volumeMode: Filesystem

--- a/roles/rhoai/templates/storageclass-gp3.yml.j2
+++ b/roles/rhoai/templates/storageclass-gp3.yml.j2
@@ -1,0 +1,14 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ rhoai_storage_class_name }}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+    description: "Gryphon Forge default gp3 via AWS EBS CSI (RHOAI / PVC workloads)"
+provisioner: {{ rhoai_storage_class_provisioner }}
+parameters:
+  type: {{ rhoai_storage_class_type }}
+  encrypted: "{{ 'true' if rhoai_storage_class_encrypted | bool else 'false' }}"
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer

--- a/roles/rhoai/templates/subscription.yml.j2
+++ b/roles/rhoai/templates/subscription.yml.j2
@@ -1,0 +1,14 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ rhoai_sub_package }}
+  namespace: {{ rhoai_sub_namespace }}
+spec:
+  name: {{ rhoai_sub_package }}
+  channel: {{ rhoai_sub_channel }}
+  source: {{ rhoai_sub_catalog }}
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic
+{% if rhoai_sub_starting_csv | default('') | length > 0 %}
+  startingCSV: {{ rhoai_sub_starting_csv }}
+{% endif %}

--- a/roles/validation/tasks/oauth_apps_connectivity.yml
+++ b/roles/validation/tasks/oauth_apps_connectivity.yml
@@ -26,9 +26,9 @@
       vars:
         _st: "{{ validation_oauth_apps_uri.status | default(-1) }}"
         _ok: "{{ validation_oauth_apps_uri is succeeded }}"
-        _via_api: "{{ forge_oauth_apps_via_api_nlb | default((ocp_version | default('4.14')) is version('4.21', '<')) }}"
-        _path_label: "{{ 'API NLB :443 express lane' if (_via_api | bool) else 'ingress (*.apps target)' }}"
-        _tg_hint: "{{ 'API NLB listener 443 / ' ~ cluster_name ~ '-oauth-tg' if (_via_api | bool) else 'ingress NLB/ALB' }}"
+        _via_api: "{{ forge_oauth_apps_via_api_nlb | default((ocp_version | default('4.14')) is version('4.21', '<')) | bool }}"
+        _path_label: "{{ 'API NLB :443 express lane' if _via_api else 'ingress (*.apps target)' }}"
+        _tg_hint: "{{ 'API NLB listener 443 / ' ~ cluster_name ~ '-oauth-tg' if _via_api else 'ingress NLB/ALB' }}"
         _oauth_conn_rep: >-
           {% if not _ok %}
           FAILED msg={{ (validation_oauth_apps_uri.msg | default('')) | regex_replace('\n', ' ') | truncate(200) }}

--- a/scripts/discover-mirror-release-tag.sh
+++ b/scripts/discover-mirror-release-tag.sh
@@ -15,7 +15,8 @@
 #
 # Note: The ocp-release payload uses tags like 4.21.z-x86_64 (not 4.21.z-x86_64-<component>). A repo may list only
 # component tags under .../openshift/release/openshift/release; this script skips those and prefers
-# openshift/release/openshift-release-dev/ocp-release or openshift-release-dev/ocp-release when REPO is openshift/release.
+# openshift/release/openshift/release-images (oc-mirror v2), then openshift/release/openshift-release-dev/ocp-release
+# or openshift-release-dev/ocp-release when REPO is openshift/release.
 
 set -euo pipefail
 
@@ -231,8 +232,10 @@ discover_via_curl() {
   local auth out url last_err try
   local -a try_paths=("${REPO}")
   if [[ "${REPO}" == "openshift/release" ]]; then
-    # Prefer ocp-release repos; openshift/release/openshift/release often holds only per-component tags (4.21.z-arch-name).
+    # oc-mirror v2 uses openshift/release/openshift/release-images; v1 / oc adm uses openshift-release-dev/ocp-release.
+    # openshift/release/openshift/release holds only per-component tags (4.21.z-arch-name).
     try_paths+=(
+      "openshift/release/openshift/release-images"
       "openshift/release/openshift-release-dev/ocp-release"
       "openshift-release-dev/ocp-release"
       "openshift/release/openshift/release"

--- a/scripts/mirror-rhoai.sh
+++ b/scripts/mirror-rhoai.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Mirror RHOAI (+ cert-manager, optional NFD/GPU/OSSM3) into the Nest registry for Gryphon Forge.
+#
+# Run on the Nest bastion (internet + reachability to mirror.fsi.internal).
+# After success, point Ansible at the generated cluster-resources:
+#
+#   ansible-playbook playbooks/install_rhoai.yml ... \
+#     -e rhoai_apply_mirror_resources=true \
+#     -e rhoai_mirror_resources_dir=$HOME/oc-mirror-workspace-rhoai/working-dir/cluster-resources
+#
+# Usage:
+#   export MIRROR_REGISTRY_URL=mirror.fsi.internal
+#   export PULL_SECRET=~/.openshift/pull-secret
+#   export OCP_MINOR=4.22          # operator index tag minor
+#   export RHOAI_CHANNEL=stable-3.4
+#   export RHOAI_VERSION=3.4.2     # min/maxVersion pin; confirm supported configs
+#   ./scripts/mirror-rhoai.sh
+#
+# Optional:
+#   INCLUDE_GPU=true|false (default true)
+#   INCLUDE_SERVICEMESH=true|false (default false — RHOAI 3.x RawDeployment)
+#   INCLUDE_WORKBENCH_IMAGES=true|false (default true; large)
+#   WORKSPACE=$HOME/oc-mirror-workspace-rhoai
+#   DEST_PATH=openshift/rhoai
+#   IMAGESET=$HOME/imagesets/imageset-config-rhoai.yaml
+#   MIN_FREE_GB=200
+
+set -euo pipefail
+
+MIRROR_REGISTRY_URL="${MIRROR_REGISTRY_URL:?set MIRROR_REGISTRY_URL (e.g. mirror.fsi.internal)}"
+PULL_SECRET="${PULL_SECRET:-${PULL_SECRET_PATH:-$HOME/.openshift/pull-secret}}"
+OCP_MINOR="${OCP_MINOR:-4.22}"
+RHOAI_CHANNEL="${RHOAI_CHANNEL:-stable-3.4}"
+RHOAI_VERSION="${RHOAI_VERSION:-3.4.2}"
+INCLUDE_GPU="${INCLUDE_GPU:-true}"
+INCLUDE_SERVICEMESH="${INCLUDE_SERVICEMESH:-false}"
+INCLUDE_WORKBENCH_IMAGES="${INCLUDE_WORKBENCH_IMAGES:-true}"
+WORKSPACE="${WORKSPACE:-$HOME/oc-mirror-workspace-rhoai}"
+DEST_PATH="${DEST_PATH:-openshift/rhoai}"
+IMAGESET="${IMAGESET:-$HOME/imagesets/imageset-config-rhoai.yaml}"
+MIN_FREE_GB="${MIN_FREE_GB:-200}"
+OC_MIRROR_BIN="${OC_MIRROR_BIN:-$(command -v oc-mirror || true)}"
+
+die() { echo "error: $*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"; }
+
+need python3
+[[ -f "$PULL_SECRET" ]] || die "pull secret not found: $PULL_SECRET"
+[[ -n "$OC_MIRROR_BIN" && -x "$OC_MIRROR_BIN" ]] || die "oc-mirror not found; set OC_MIRROR_BIN or install on PATH"
+
+# Free space under workspace parent (portable df)
+_parent="$(dirname "$WORKSPACE")"
+mkdir -p "$_parent"
+_avail_kb="$(df -Pk "$_parent" | awk 'NR==2 {print $4}')"
+_avail_gb="$((_avail_kb / 1024 / 1024))"
+if (( _avail_gb < MIN_FREE_GB )); then
+  die "only ${_avail_gb}GiB free under ${_parent}; need >= ${MIN_FREE_GB}GiB (full RHOAI+workbenches can exceed 500GiB)"
+fi
+
+mkdir -p "$(dirname "$IMAGESET")" "$WORKSPACE"
+
+# nfd shares redhat-operator-index with rhods (must not duplicate catalog entries)
+GPU_NFD_PKG=""
+GPU_CERT_CATALOG=""
+if [[ "$INCLUDE_GPU" == "true" ]]; then
+  GPU_NFD_PKG="$(cat <<EOF
+        - name: nfd
+          defaultChannel: stable
+          channels:
+            - name: stable
+EOF
+)"
+  GPU_CERT_CATALOG="$(cat <<EOF
+    - catalog: registry.redhat.io/redhat/certified-operator-index:v${OCP_MINOR}
+      packages:
+        - name: gpu-operator-certified
+          defaultChannel: stable
+          channels:
+            - name: stable
+EOF
+)"
+fi
+
+MESH_BLOCK=""
+if [[ "$INCLUDE_SERVICEMESH" == "true" ]]; then
+  MESH_BLOCK="$(cat <<EOF
+        - name: servicemeshoperator3
+          defaultChannel: stable
+          channels:
+            - name: stable
+EOF
+)"
+fi
+
+ADDITIONAL_IMAGES_BLOCK="  additionalImages: []"
+if [[ "$INCLUDE_WORKBENCH_IMAGES" == "true" ]]; then
+  echo "==> Fetching workbench additionalImages from rhoai-disconnected-install-helper (${RHOAI_VERSION})"
+  _helper_url="https://raw.githubusercontent.com/red-hat-data-services/rhoai-disconnected-install-helper/main/rhoai-${RHOAI_VERSION}.md"
+  _imgs="$(curl -sfL "$_helper_url" \
+    | awk '/^# Additional images/{a=1; next} /^# (Unsupported|ImageSetConfiguration)/{a=0} a' \
+    | grep -oE '(quay\.io|registry\.redhat\.io)[^ ]+@sha256:[a-f0-9]+' \
+    | sort -u || true)"
+  if [[ -z "$_imgs" ]]; then
+    echo "warn: no additionalImages parsed from ${_helper_url}; continuing with empty list" >&2
+    ADDITIONAL_IMAGES_BLOCK="  additionalImages: []"
+  else
+    ADDITIONAL_IMAGES_BLOCK="  additionalImages:"
+    while IFS= read -r ref; do
+      [[ -n "$ref" ]] || continue
+      ADDITIONAL_IMAGES_BLOCK+=$'\n'"    - name: ${ref}"
+    done <<< "$_imgs"
+  fi
+fi
+
+cat > "$IMAGESET" <<EOF
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v2alpha1
+mirror:
+  operators:
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v${OCP_MINOR}
+      packages:
+        - name: rhods-operator
+          defaultChannel: ${RHOAI_CHANNEL}
+          channels:
+            - name: ${RHOAI_CHANNEL}
+              minVersion: "${RHOAI_VERSION}"
+              maxVersion: "${RHOAI_VERSION}"
+        - name: openshift-cert-manager-operator
+          defaultChannel: stable-v1
+          channels:
+            - name: stable-v1
+${MESH_BLOCK}
+${GPU_NFD_PKG}
+${GPU_CERT_CATALOG}
+${ADDITIONAL_IMAGES_BLOCK}
+EOF
+
+echo "==> ImageSetConfiguration written to $IMAGESET"
+echo "==> Mirroring to docker://${MIRROR_REGISTRY_URL}/${DEST_PATH}"
+echo "    workspace: $WORKSPACE"
+
+"$OC_MIRROR_BIN" --v2 \
+  -c "$IMAGESET" \
+  --workspace "file://${WORKSPACE}" \
+  "docker://${MIRROR_REGISTRY_URL}/${DEST_PATH}" \
+  --authfile "$PULL_SECRET"
+
+_resources="${WORKSPACE}/working-dir/cluster-resources"
+[[ -d "$_resources" ]] || die "expected cluster-resources at ${_resources}"
+
+echo
+echo "Mirror complete."
+echo "Apply mirrored CRs then install RHOAI:"
+echo
+echo "  ansible-playbook playbooks/install_rhoai.yml -i inventory/hosts.yml \\"
+echo "    -e @../gryphon-foundry/foundry_output.json \\"
+echo "    -e rhoai_apply_mirror_resources=true \\"
+echo "    -e rhoai_mirror_resources_dir=${_resources}"
+echo


### PR DESCRIPTION
## Summary
- Add day-2 disconnected OpenShift AI install: `roles/rhoai`, `playbooks/install_rhoai.yml`, `scripts/mirror-rhoai.sh`, and `docs/RHOAI-disconnected-install.md`
- Default GPU workers to **3× `g6.4xlarge`** for RHOAI workloads (`inventory/group_vars/all.yml`)
- Includes preceding oc-mirror / bastion sync fixes from the branch base that are not yet on `dev`

## Test plan
- [ ] `ansible-playbook playbooks/install_rhoai.yml --syntax-check`
- [ ] `ansible-lint` (CI)
- [ ] Confirm CI syntax-check covers `playbooks/*.yml` including `install_rhoai.yml`
- [ ] Optional: dry-run mirror helper docs against a Nest bastion; install playbook against a lab cluster with mirrored catalogs


Made with [Cursor](https://cursor.com)